### PR TITLE
Data explorer map

### DIFF
--- a/app/components/Data-Explorer/DataExplorer.tsx
+++ b/app/components/Data-Explorer/DataExplorer.tsx
@@ -5,7 +5,8 @@ import React, { useState, useEffect, useRef } from 'react'
 import { globalWarmingLevelsList } from '@/app/lib/data-explorer/global-warming-levels'
 import { metricsList } from '@/app/lib/data-explorer/metrics'
 import Map from './Map'
-
+import Grid from '@mui/material/Unstable_Grid2'
+import Typography from '@mui/material/Typography'
 type DataExplorerProps = {
     data: any
 }
@@ -15,9 +16,9 @@ export default function DataExplorer({ data }: DataExplorerProps) {
     const [metricSelected, setMetricSelected] = useState<number>(0)
 
     return (
-        <div>
-            Data Explorer content
+        <Grid container sx={{ height: '100%', flexDirection: "column", flexWrap: "nowrap", flexGrow: 1 }}>
+            <Typography variant="body1">Data Explorer content</Typography>
             <Map gwlSelected={gwlSelected} setGwlSelected={setGwlSelected} metricSelected={metricSelected} setMetricSelected={setMetricSelected} data={data}></Map>
-        </div>
+        </Grid>
     )
 }

--- a/app/components/Data-Explorer/DataExplorer.tsx
+++ b/app/components/Data-Explorer/DataExplorer.tsx
@@ -6,7 +6,6 @@ import { globalWarmingLevelsList } from '@/app/lib/data-explorer/global-warming-
 import { metricsList } from '@/app/lib/data-explorer/metrics'
 import MapboxMap from './Map'
 import Grid from '@mui/material/Unstable_Grid2'
-import Typography from '@mui/material/Typography'
 type DataExplorerProps = {
     data: any
 }
@@ -17,7 +16,6 @@ export default function DataExplorer({ data }: DataExplorerProps) {
 
     return (
         <Grid container sx={{ height: '100%', flexDirection: "column", flexWrap: "nowrap", flexGrow: 1 }}>
-            {/* <Typography variant="body1">Data Explorer content</Typography> */}
             <MapboxMap gwlSelected={gwlSelected} setGwlSelected={setGwlSelected} metricSelected={metricSelected} setMetricSelected={setMetricSelected} data={data}></MapboxMap>
         </Grid>
     )

--- a/app/components/Data-Explorer/DataExplorer.tsx
+++ b/app/components/Data-Explorer/DataExplorer.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect, useRef } from 'react'
 
 import { globalWarmingLevelsList } from '@/app/lib/data-explorer/global-warming-levels'
 import { metricsList } from '@/app/lib/data-explorer/metrics'
-import Map from './Map'
+import MapboxMap from './Map'
 import Grid from '@mui/material/Unstable_Grid2'
 import Typography from '@mui/material/Typography'
 type DataExplorerProps = {
@@ -17,8 +17,8 @@ export default function DataExplorer({ data }: DataExplorerProps) {
 
     return (
         <Grid container sx={{ height: '100%', flexDirection: "column", flexWrap: "nowrap", flexGrow: 1 }}>
-            <Typography variant="body1">Data Explorer content</Typography>
-            <Map gwlSelected={gwlSelected} setGwlSelected={setGwlSelected} metricSelected={metricSelected} setMetricSelected={setMetricSelected} data={data}></Map>
+            {/* <Typography variant="body1">Data Explorer content</Typography> */}
+            <MapboxMap gwlSelected={gwlSelected} setGwlSelected={setGwlSelected} metricSelected={metricSelected} setMetricSelected={setMetricSelected} data={data}></MapboxMap>
         </Grid>
     )
 }

--- a/app/components/Data-Explorer/Map.tsx
+++ b/app/components/Data-Explorer/Map.tsx
@@ -94,7 +94,7 @@ const throttledFetchPoint = throttle(async (
         
         if (response.ok) {
             const data = await response.json();
-            const gwlIndex = GWL_VALUES.indexOf(gwl);
+            const gwlIndex = GWL_VALUES.indexOf(gwl as typeof GWL_VALUES[number]);
             const value = data.data[gwlIndex];
             callback(value ?? null);
         }
@@ -210,6 +210,17 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
 
         const isLoading = !mounted || !tileJson;
 
+        const handleMapError = (event: any) => {
+            // Prevent error from reaching console if it's a tile loading error
+            if (event.error?.status === 404 && event.error.url?.includes('WebMercatorQuad')) {
+                event.preventDefault();  // Stops the error from being logged
+                return;
+            }
+            
+            // Let other errors through to console
+            console.error(event.error);
+        };
+
         if (!mounted) {
             return (
                 <Grid container sx={{ height: '100%', flexDirection: "column", flexWrap: "nowrap", flexGrow: 1 }}>
@@ -303,6 +314,7 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
                             minZoom={3.5}
                             maxBounds={MAP_BOUNDS}
                             style={{ width: "100%", height: "100%" }}
+                            onError={handleMapError}
                         >
                             {tileJson && (
                                 <Source 

--- a/app/components/Data-Explorer/Map.tsx
+++ b/app/components/Data-Explorer/Map.tsx
@@ -5,6 +5,7 @@ import React, { useState, useEffect, useRef, useMemo, forwardRef, useImperativeH
 import { Marker, Map, Layer, Source, MapMouseEvent, NavigationControl, MapRef, ScaleControl } from 'react-map-gl'
 import Box from '@mui/material/Box'
 import Grid from '@mui/material/Unstable_Grid2'
+import { MapLegend } from './MapLegend'
 
 type MapProps = {
     metricSelected: number;
@@ -81,6 +82,11 @@ const MapboxMap = forwardRef<MapRef | null, MapProps>(
                                 />
                             </Source>
                         )}
+                        <MapLegend 
+                            colormap="magma"
+                            min={1.18}
+                            max={35.19}
+                        />
                     </Map>
                 </Box>
         </Grid>

--- a/app/components/Data-Explorer/Map.tsx
+++ b/app/components/Data-Explorer/Map.tsx
@@ -215,7 +215,14 @@ const MapboxMap = forwardRef<MapRef | null, MapProps>(
                 </Box>
                 <Box sx={{ height: '100%', flexDirection: "column", flexWrap: "nowrap", flexGrow: 1, position: "relative" }} id="map">
                     {!tileJson ? (
-                        <LoadingSpinner />
+                        <Box sx={{ 
+                            position: 'absolute', 
+                            top: '50%', 
+                            left: '50%', 
+                            transform: 'translate(-50%, -50%)'
+                        }}>
+                            <LoadingSpinner />
+                        </Box>
                     ) : (
                         <Map
                             ref={mapRef}

--- a/app/components/Data-Explorer/Map.tsx
+++ b/app/components/Data-Explorer/Map.tsx
@@ -1,16 +1,56 @@
 'use client'
 
 import 'mapbox-gl/dist/mapbox-gl.css'
-import React, { useState, useEffect, useRef, useMemo, forwardRef, useImperativeHandle, useCallback } from 'react'
-import { Marker, Map, Layer, Source, MapMouseEvent, NavigationControl, MapRef, ScaleControl, Popup } from 'react-map-gl'
+import React, { useState, useEffect, useRef, forwardRef, useImperativeHandle } from 'react'
+import { Map, MapRef, Layer, Source, MapMouseEvent, NavigationControl, ScaleControl, Popup } from 'react-map-gl'
 import Box from '@mui/material/Box'
 import Grid from '@mui/material/Unstable_Grid2'
 import { MapLegend } from './MapLegend'
+import LoadingSpinner from '../Global/LoadingSpinner'
+import { throttle } from 'lodash'
+
+// remove me, for demo only v
 import Select from '@mui/material/Select'
 import MenuItem from '@mui/material/MenuItem'
 import FormControl from '@mui/material/FormControl'
 import InputLabel from '@mui/material/InputLabel'
-import LoadingSpinner from '../Global/LoadingSpinner'
+
+const GWL_VALUES = ["1.5", "2.0", "2.5", "3.0"] as const;
+// remove me, for demo only ^
+
+const INITIAL_VIEW_STATE = {
+    longitude: -120,
+    latitude: 37.4,
+    zoom: 5
+} as const;
+
+const THROTTLE_DELAY = 100 as const;
+const BASE_URL = 'https://2fxwkf3nc6.execute-api.us-west-2.amazonaws.com' as const;
+const RASTER_TILE_LAYER_OPACITY = 0.8 as const;
+
+// edit me v
+const VARIABLES = {
+    'TX99p': {
+        title: 'Maximum air temperature days exceeding 99th percentile',
+        path: 's3://cadcat/tmp/era/wrf/cae/mm4mean/ssp370/yr/TX99p/d02/TX99p.zarr',
+        rescale: '1.18,35.19',
+        colormap: 'oranges' // case sensitive
+    },
+    'R99p': {
+        title: 'Absolute change in 99th percentile precipitation',
+        path: 's3://cadcat/tmp/era/wrf/cae/mm4mean/ssp370/yr/R99p/d02/R99p.zarr',
+        rescale: '-4.866,39.417',
+        colormap: 'blues'
+    },
+    'ffwige50': {
+        title: 'Number of days with FFWI greater than 50',
+        path: 's3://cadcat/tmp/era/wrf/cae/mm4mean/ssp370/yr/ffwige50/d02/ffwige50.zarr',
+        rescale: '-197.96,92.158',
+        colormap: 'reds'
+    }
+} as const;
+// edit me ^
+
 
 type MapProps = {
     metricSelected: number;
@@ -20,121 +60,98 @@ type MapProps = {
     setGwlSelected: (gwl: number) => void,
 }
 
-const VARIABLES = {
-    'TX99p': {
-        title: 'Maximum air temperature days exceeding 99th percentile',
-        path: 's3://cadcat/tmp/era/wrf/cae/mm4mean/ssp370/yr/TX99p/d02/TX99p.zarr',
-        rescale: '1.18,35.19'
-    },
-    'R99p': {
-        title: 'Absolute change in 99th percentile precipitation',
-        path: 's3://cadcat/tmp/era/wrf/cae/mm4mean/ssp370/yr/R99p/d02/R99p.zarr',
-        rescale: '0,50'  // Rescale values?
-    },
-    'ffwige50': {
-        title: 'Number of days with FFWI greater than 50',
-        path: 's3://cadcat/tmp/era/wrf/cae/mm4mean/ssp370/yr/ffwige50/d02/ffwige50.zarr',
-        rescale: '0,30'  // Rescale values?
-    }
-} as const;
-
 type VariableKey = keyof typeof VARIABLES;
 
-const COLORMAPS = ["magma", "viridis", "inferno", "plasma", "cividis"] as const;
+type TileJson = {
+    tiles: string[];
+    tileSize?: number;
+};
 
-const GWL_VALUES = ["1.5", "2.0", "2.5", "3.0"] as const;
-
-const MapboxMap = forwardRef<MapRef | null, MapProps>(
+const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
     ({ metricSelected, gwlSelected, data, setMetricSelected, setGwlSelected }, ref) => {
+        
+        // Refs
         const mapRef = useRef<MapRef | null>(null)
-        const [mapLoaded, setMapLoaded] = useState(false)
-        const [tileJson, setTileJson] = useState(null)
+
+        // Forward the internal ref to the parent
+        useImperativeHandle(ref, () => mapRef.current || undefined)
+
+        // State
         const [mounted, setMounted] = useState(false)
-        const [colormap, setColormap] = useState<typeof COLORMAPS[number]>("magma")
-        const [selectedVariable, setSelectedVariable] = useState<VariableKey>("TX99p")
-        const [selectedGwl, setSelectedGwl] = useState<typeof GWL_VALUES[number]>("3.0")
+        const [mapLoaded, setMapLoaded] = useState(false)
+        const [tileJson, setTileJson] = useState<TileJson | null>(null)
         const [hoverInfo, setHoverInfo] = useState<{
             longitude: number;
             latitude: number;
             value: number | null;
         } | null>(null);
 
-        const initialViewState = {
-            longitude: -120,
-            latitude: 37.4,
-            zoom: 5
+        // Effects
+        useEffect(() => {
+            setMounted(true)
+        }, [])
+
+        useEffect(() => {
+            return () => {
+                throttledFetchPoint.cancel();
+            };
+        }, []);
+
+        // Derived state
+        const variableKeys = Object.keys(VARIABLES) as VariableKey[];
+        const currentVariable = variableKeys[metricSelected] || variableKeys[0];
+        const currentGwl = GWL_VALUES[gwlSelected] || GWL_VALUES[0];
+        
+        const currentVariableData = VARIABLES[currentVariable];
+        if (!currentVariableData) {
+            console.error('Invalid variable selected:', currentVariable);
+            return null;
         }
 
-        // Forward the internal ref to the parent using useImperativeHandle
-        useImperativeHandle(ref, () => mapRef.current as MapRef)
+        const currentColormap = currentVariableData.colormap;
 
-        const handleMapLoad = (e: any) => {
-            const map = e.target;
-            mapRef.current = map;
-            setMapLoaded(true);
-        }
-
-        const handleHover = async (event: MapMouseEvent) => {
-            console.log('Hover event triggered');
-            const { lngLat: { lng, lat } } = event;
-            
-            if (!mapRef.current) {
-                console.log('No map ref');
-                return;
-            }
-
+        const throttledFetchPoint = throttle(async (
+            lng: number, 
+            lat: number, 
+            path: string, 
+            variable: string,
+            gwl: string,
+            callback: (value: number | null) => void
+        ) => {
             try {
                 const response = await fetch(
-                    `https://2fxwkf3nc6.execute-api.us-west-2.amazonaws.com/point/${lng},${lat}?` + 
-                    `url=${encodeURIComponent(VARIABLES[selectedVariable].path)}&` +
-                    `variable=${selectedVariable}`
+                    `${BASE_URL}/point/${lng},${lat}?` + 
+                    `url=${encodeURIComponent(path)}&` +
+                    `variable=${variable}`
                 );
                 
                 if (response.ok) {
                     const data = await response.json();
-                    console.log('Point data:', data);
-                    
-                    // Get the value from the data array based on the selected GWL
-                    const gwlIndex = GWL_VALUES.indexOf(selectedGwl);
+                    const gwlIndex = GWL_VALUES.indexOf(gwl);
                     const value = data.data[gwlIndex];
-                    
-                    // Only set hover info if we have a valid value
-                    if (value !== undefined && value !== null) {
-                        setHoverInfo({
-                            longitude: lng,
-                            latitude: lat,
-                            value: value
-                        });
-                    } else {
-                        setHoverInfo(null);
-                    }
+                    callback(value ?? null);
                 }
             } catch (error) {
                 console.error('Error fetching point data:', error);
-                setHoverInfo(null);
+                callback(null);
             }
-        };
+        }, THROTTLE_DELAY);
 
         useEffect(() => {
             const fetchTileJson = async () => {
-                // Base URL for the API
-                const baseUrl = 'https://2fxwkf3nc6.execute-api.us-west-2.amazonaws.com/WebMercatorQuad/tilejson.json';
-                
-                // Construct query parameters
                 const params = {
-                    url: VARIABLES[selectedVariable].path,
-                    variable: selectedVariable,
-                    datetime: selectedGwl,
-                    rescale: VARIABLES[selectedVariable].rescale,
-                    colormap_name: colormap
+                    url: currentVariableData.path,
+                    variable: currentVariable,
+                    datetime: currentGwl,
+                    rescale: currentVariableData.rescale,
+                    colormap_name: currentColormap
                 };
 
-                // Convert params to query string
                 const queryString = Object.entries(params)
                     .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
                     .join('&');
 
-                const url = `${baseUrl}?${queryString}`;
+                const url = `${BASE_URL}/WebMercatorQuad/tilejson.json?${queryString}`;
 
                 try {
                     const response = await fetch(url);
@@ -148,32 +165,74 @@ const MapboxMap = forwardRef<MapRef | null, MapProps>(
                     console.error('Full URL:', url);
                 }
             };
-
             fetchTileJson();
-        }, [metricSelected, selectedGwl, colormap, selectedVariable]);
+        }, [metricSelected, gwlSelected, currentVariable, currentVariableData, currentGwl]);
 
-        // Handle hydration mismatch
-        useEffect(() => {
-            setMounted(true)
-        }, [])
-
-        // Skip rendering select components until after hydration
         if (!mounted) {
-            return null
+            return (
+                <Grid container sx={{ height: '100%', flexDirection: "column", flexWrap: "nowrap", flexGrow: 1 }}>
+                    <Box sx={{ 
+                        position: 'absolute', 
+                        top: '50%', 
+                        left: '50%', 
+                        transform: 'translate(-50%, -50%)'
+                    }}>
+                        <LoadingSpinner />
+                    </Box>
+                </Grid>
+            );
         }
+
+        const handleMapLoad = (e: any) => {
+            const map = e.target;
+            mapRef.current = map;
+            setMapLoaded(true);
+        }
+
+        const handleHover = (event: MapMouseEvent) => {
+            if (!mapLoaded || !mapRef.current) {
+                return;
+            }
+
+            const { lngLat: { lng, lat } } = event;
+            
+            throttledFetchPoint(
+                lng, 
+                lat, 
+                VARIABLES[currentVariable].path,
+                currentVariable,
+                currentGwl,
+                (value) => {
+                    if (value !== null) {
+                        setHoverInfo({
+                            longitude: lng,
+                            latitude: lat,
+                            value
+                        });
+                    } else {
+                        setHoverInfo(null);
+                    }
+                }
+            );
+        };
 
         return (
             <Grid container sx={{ height: '100%', flexDirection: "column", flexWrap: "nowrap", flexGrow: 1 }}>
+                {/* remove v */}
                 <Box>
                     {/* <p>{metricSelected}</p>
                     <p>{gwlSelected}</p> */}
+
                     <FormControl sx={{ m: 1, minWidth: 120 }}>
                         <InputLabel id="variable-select-label">Variable</InputLabel>
                         <Select
                             labelId="variable-select-label"
-                            value={selectedVariable}
+                            value={currentVariable}
                             label="Variable"
-                            onChange={(e) => setSelectedVariable(e.target.value as VariableKey)}
+                            onChange={(e) => {
+                                const newIndex = variableKeys.indexOf(e.target.value as VariableKey);
+                                setMetricSelected(newIndex);
+                            }}
                         >
                             {Object.entries(VARIABLES).map(([key, value]) => (
                                 <MenuItem key={key} value={key}>
@@ -186,87 +245,78 @@ const MapboxMap = forwardRef<MapRef | null, MapProps>(
                         <InputLabel id="gwl-select-label">GWL</InputLabel>
                         <Select
                             labelId="gwl-select-label"
-                            value={selectedGwl}
+                            value={gwlSelected}
                             label="GWL"
-                            onChange={(e) => setSelectedGwl(e.target.value as typeof GWL_VALUES[number])}
+                            onChange={(e) => setGwlSelected(Number(e.target.value))}
                         >
-                            {GWL_VALUES.map((gwl) => (
-                                <MenuItem key={gwl} value={gwl}>
+                            {GWL_VALUES.map((gwl, index) => (
+                                <MenuItem key={gwl} value={index}>
                                     {gwl}°C
                                 </MenuItem>
                             ))}
                         </Select>
                     </FormControl>
-                    <FormControl sx={{ m: 1, minWidth: 120 }}>
-                        <InputLabel id="colormap-select-label">Colormap</InputLabel>
-                        <Select
-                            labelId="colormap-select-label"
-                            value={colormap}
-                            label="Colormap"
-                            onChange={(e) => setColormap(e.target.value as typeof COLORMAPS[number])}
-                        >
-                            {COLORMAPS.map((cm) => (
-                                <MenuItem key={cm} value={cm}>
-                                    {cm.charAt(0).toUpperCase() + cm.slice(1)}
-                                </MenuItem>
-                            ))}
-                        </Select>
-                    </FormControl>
                 </Box>
-                <Box sx={{ height: '100%', flexDirection: "column", flexWrap: "nowrap", flexGrow: 1, position: "relative" }} id="map">
-                    {!tileJson ? (
+                {/* remove ^ */}
+                <Box sx={{ height: '100%' }} id="map">
+                    {!tileJson && (
                         <Box sx={{ 
                             position: 'absolute', 
                             top: '50%', 
                             left: '50%', 
-                            transform: 'translate(-50%, -50%)'
+                            transform: 'translate(-50%, -50%)',
+                            zIndex: 3
                         }}>
                             <LoadingSpinner />
                         </Box>
-                    ) : (
+                    )}
+                    <Box style={{ position: 'relative', width: '100%', height: '100%' }}>
                         <Map
                             ref={mapRef}
                             onLoad={handleMapLoad}
                             onMouseMove={handleHover}
                             mapboxAccessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN}
-                            initialViewState={initialViewState}
-                            mapStyle="mapbox://styles/mapbox/streets-v9"
+                            initialViewState={INITIAL_VIEW_STATE}
+                            mapStyle="mapbox://styles/mapbox/light-v11"
                             scrollZoom={false}
                             minZoom={3.5}
-                            style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }}
+                            style={{ width: "100%", height: "100%" }}
                         >
-                            <NavigationControl position="bottom-left" />
+                            <NavigationControl position="top-right" />
                             <ScaleControl position="bottom-right" maxWidth={100} unit="metric" />
-                            <Source 
-                                id="raster-source"
-                                type="raster"
-                                tiles={tileJson.tiles}
-                                tileSize={256}
-                            >
-                                <Layer
-                                    id="tile-layer"
+                            {tileJson && (
+                                <Source 
+                                    id="raster-source"
                                     type="raster"
-                                    paint={{ 'raster-opacity': 0.8 }}
-                                />
-                            </Source>
-                            <MapLegend 
-                                colormap={colormap}
-                                min={parseFloat(VARIABLES[selectedVariable].rescale.split(',')[0])}
-                                max={parseFloat(VARIABLES[selectedVariable].rescale.split(',')[1])}
-                                title={VARIABLES[selectedVariable].title}
-                            />
-                            {hoverInfo && (
-                                <Popup
-                                    longitude={hoverInfo.longitude}
-                                    latitude={hoverInfo.latitude}
-                                    closeButton={false}
-                                    className="county-info-popup"
+                                    tiles={tileJson.tiles}
+                                    tileSize={tileJson.tileSize || 256}
                                 >
-                                    Value: {hoverInfo.value?.toFixed(2)}
-                                </Popup>
+                                    <Layer
+                                        id="tile-layer"
+                                        type="raster"
+                                        paint={{ 'raster-opacity': RASTER_TILE_LAYER_OPACITY }}
+                                    />
+                                </Source>
                             )}
                         </Map>
-                    )}
+                        <Box sx={{ 
+                            position: 'absolute',
+                            bottom: 40,
+                            left: 250,
+                            backgroundColor: 'white',
+                            padding: 2,
+                            boxShadow: 0,
+                            borderRadius: 1,
+                            zIndex: 2
+                        }}>
+                            <MapLegend 
+                                colormap={currentColormap}
+                                min={parseFloat(currentVariableData.rescale.split(',')[0])}
+                                max={parseFloat(currentVariableData.rescale.split(',')[1])}
+                                title={currentVariableData.title}
+                            />
+                        </Box>
+                    </Box>
                 </Box>
             </Grid>
         )
@@ -276,5 +326,4 @@ const MapboxMap = forwardRef<MapRef | null, MapProps>(
 MapboxMap.displayName = 'MapboxMap'
 
 export default MapboxMap
-
 

--- a/app/components/Data-Explorer/Map.tsx
+++ b/app/components/Data-Explorer/Map.tsx
@@ -1,8 +1,11 @@
 'use client'
 
-import React, { useState, useEffect, useRef, useMemo } from 'react'
+import 'mapbox-gl/dist/mapbox-gl.css'
+import React, { useState, useEffect, useRef, useMemo, forwardRef, useImperativeHandle } from 'react'
+import { Marker, Map, Layer, Source, MapMouseEvent, NavigationControl, MapRef, ScaleControl } from 'react-map-gl'
+import Box from '@mui/material/Box'
+import Grid from '@mui/material/Unstable_Grid2'
 
-// The map props are inherited from the parent DataExplorer and can be used to set and access the Data Explorer's variables
 type MapProps = {
     metricSelected: number;
     gwlSelected: number;
@@ -11,13 +14,54 @@ type MapProps = {
     setGwlSelected: (gwl: number) => void,
 }
 
-export default function Map({ metricSelected, gwlSelected, data }: MapProps) {
+const MapboxMap = forwardRef<MapRef | null, MapProps>(
+    ({ metricSelected, gwlSelected, data, setMetricSelected, setGwlSelected }, ref) => {
+        const mapRef = useRef<MapRef | null>(null)
+        const [mapLoaded, setMapLoaded] = useState(false)
+
+        const initialViewState = {
+            longitude: -122.4,
+            latitude: 37.8,
+            zoom: 8
+        }
+
+        // Forward the internal ref to the parent using useImperativeHandle
+        useImperativeHandle(ref, () => mapRef.current as MapRef)
+
+        const handleMapLoad = (e: any) => {
+            const map = e.target;
+            mapRef.current = map;
+            setMapLoaded(true);
+        }
+
     return (
-        <div>
-            <p>{metricSelected}</p>
-            <p>{gwlSelected}</p>
-            Map Code
-        </div>
+        <Grid container sx={{ height: '100%', flexDirection: "column", flexWrap: "nowrap", flexGrow: 1 }}>
+            <Box>
+                <p>{metricSelected}</p>
+                <p>{gwlSelected}</p>
+            </Box>
+                <Box sx={{ height: '100%', flexDirection: "column", flexWrap: "nowrap", flexGrow: 1, position: "relative" }} id="map">
+                    <Map
+                        ref={mapRef}
+                        onLoad={handleMapLoad}
+                        mapboxAccessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN}
+                        initialViewState={initialViewState}
+                        mapStyle="mapbox://styles/mapbox/streets-v9"
+                        scrollZoom={false}
+                        minZoom={3.5}
+                        style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }}
+                    >
+                        <NavigationControl position="bottom-left" />
+                        <ScaleControl position="bottom-right" maxWidth={100} unit="metric" />
+                    </Map>
+                </Box>
+        </Grid>
     )
-}
+    }
+)
+
+MapboxMap.displayName = 'MapboxMap'
+
+export default MapboxMap
+
 

--- a/app/components/Data-Explorer/Map.tsx
+++ b/app/components/Data-Explorer/Map.tsx
@@ -318,7 +318,7 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
                 </Box>
                 {/* remove ^ */}
 
-                <Box sx={{ height: '100%', position: 'relative' }} id="map">
+                <Box sx={{ height: '100%', position: 'relative' }} id="map" aria-label="Interactive map showing climate data">
                     <div style={{ position: 'relative', width: '100%', height: '100%' }}>
                         {isLoading && (
                             <Box sx={{ 
@@ -332,7 +332,7 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
                                 justifyContent: 'center',
                                 backgroundColor: 'rgba(255, 255, 255, 0.5)',
                                 zIndex: 9999
-                            }}>
+                            }} aria-live="polite">
                                 <LoadingSpinner />
                             </Box>
                         )}
@@ -348,6 +348,7 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
                             maxBounds={MAP_BOUNDS}
                             style={{ width: "100%", height: "100%" }}
                             onError={handleMapError}
+                            aria-label="Map"
                         >
                             {tileJson && (
                                 <Source 
@@ -382,14 +383,16 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
                                         })
                                     }
                                 }}
+                                aria-label="Search location"
                             />
-                            <NavigationControl position="top-right" />
-                            <ScaleControl position="bottom-right" maxWidth={100} unit="metric" />
+                            <NavigationControl position="top-right" aria-label="Navigation controls" />
+                            <ScaleControl position="bottom-right" maxWidth={100} unit="metric" aria-label="Scale control" />
                             {hoverInfo && (
                                 <MapPopup
                                     longitude={hoverInfo.longitude}
                                     latitude={hoverInfo.latitude}
                                     value={hoverInfo.value || 0}
+                                    aria-label={`Popup at longitude ${hoverInfo.longitude} and latitude ${hoverInfo.latitude}`}
                                 />
                             )}
                         </Map>
@@ -404,6 +407,7 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
                                 min={parseFloat(currentVariableData.rescale.split(',')[0])}
                                 max={parseFloat(currentVariableData.rescale.split(',')[1])}
                                 title={currentVariableData.title}
+                                aria-label="Map legend"
                             />
                         </div>
                     </div>

--- a/app/components/Data-Explorer/Map.tsx
+++ b/app/components/Data-Explorer/Map.tsx
@@ -19,6 +19,26 @@ type MapProps = {
     setGwlSelected: (gwl: number) => void,
 }
 
+const VARIABLES = {
+    'TX99p': {
+        title: 'Maximum air temperature days exceeding 99th percentile',
+        path: 's3://cadcat/tmp/era/wrf/cae/mm4mean/ssp370/yr/TX99p/d02/TX99p.zarr',
+        rescale: '1.18,35.19'
+    },
+    'R99p': {
+        title: 'Absolute change in 99th percentile precipitation',
+        path: 's3://cadcat/tmp/era/wrf/cae/mm4mean/ssp370/yr/R99p/d02/R99p.zarr',
+        rescale: '0,50'  // Rescale values?
+    },
+    'ffwige50': {
+        title: 'Number of days with FFWI greater than 50',
+        path: 's3://cadcat/tmp/era/wrf/cae/mm4mean/ssp370/yr/ffwige50/d02/ffwige50.zarr',
+        rescale: '0,30'  // Rescale values?
+    }
+} as const;
+
+type VariableKey = keyof typeof VARIABLES;
+
 const COLORMAPS = ["magma", "viridis", "inferno", "plasma", "cividis"] as const;
 
 const MapboxMap = forwardRef<MapRef | null, MapProps>(
@@ -26,7 +46,9 @@ const MapboxMap = forwardRef<MapRef | null, MapProps>(
         const mapRef = useRef<MapRef | null>(null)
         const [mapLoaded, setMapLoaded] = useState(false)
         const [tileJson, setTileJson] = useState(null)
+        const [mounted, setMounted] = useState(false)
         const [colormap, setColormap] = useState<typeof COLORMAPS[number]>("magma")
+        const [selectedVariable, setSelectedVariable] = useState<VariableKey>("TX99p")
 
         const initialViewState = {
             longitude: -120,
@@ -45,7 +67,25 @@ const MapboxMap = forwardRef<MapRef | null, MapProps>(
 
         useEffect(() => {
             const fetchTileJson = async () => {
-                const url = `https://2fxwkf3nc6.execute-api.us-west-2.amazonaws.com/WebMercatorQuad/tilejson.json?url=s3://cadcat/tmp/era/wrf/cae/mm4mean/ssp370/yr/TX99p/d02/TX99p.zarr&variable=TX99p&datetime=3.0&rescale=1.18,35.19&colormap_name=${colormap}`;
+                // Base URL for the API
+                const baseUrl = 'https://2fxwkf3nc6.execute-api.us-west-2.amazonaws.com/WebMercatorQuad/tilejson.json';
+                
+                // Construct query parameters
+                const params = {
+                    url: VARIABLES[selectedVariable].path,
+                    variable: selectedVariable,
+                    datetime: "3.0",  // Hardcoded
+                    rescale: VARIABLES[selectedVariable].rescale,
+                    colormap_name: colormap
+                };
+
+                // Convert params to query string
+                const queryString = Object.entries(params)
+                    .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+                    .join('&');
+
+                const url = `${baseUrl}?${queryString}`;
+
                 try {
                     const response = await fetch(url);
                     if (!response.ok) {
@@ -55,32 +95,59 @@ const MapboxMap = forwardRef<MapRef | null, MapProps>(
                     setTileJson(data);
                 } catch (error) {
                     console.error('Failed to fetch TileJSON:', error);
+                    console.error('Full URL:', url);
                 }
             };
 
             fetchTileJson();
-        }, [metricSelected, colormap]);
+        }, [metricSelected, gwlSelected, colormap, selectedVariable]);
 
-    return (
-        <Grid container sx={{ height: '100%', flexDirection: "column", flexWrap: "nowrap", flexGrow: 1 }}>
-            <Box>
-                <p>{metricSelected}</p>
-                <p>{gwlSelected}</p>
-                <FormControl sx={{ m: 1, minWidth: 120 }}>
-                    <InputLabel>Colormap</InputLabel>
-                    <Select
-                        value={colormap}
-                        label="Colormap"
-                        onChange={(e) => setColormap(e.target.value as typeof COLORMAPS[number])}
-                    >
-                        {COLORMAPS.map((cm) => (
-                            <MenuItem key={cm} value={cm}>
-                                {cm.charAt(0).toUpperCase() + cm.slice(1)}
-                            </MenuItem>
-                        ))}
-                    </Select>
-                </FormControl>
-            </Box>
+        // Handle hydration mismatch
+        useEffect(() => {
+            setMounted(true)
+        }, [])
+
+        // Skip rendering select components until after hydration
+        if (!mounted) {
+            return null
+        }
+
+        return (
+            <Grid container sx={{ height: '100%', flexDirection: "column", flexWrap: "nowrap", flexGrow: 1 }}>
+                <Box>
+                    <p>{metricSelected}</p>
+                    <p>{gwlSelected}</p>
+                    <FormControl sx={{ m: 1, minWidth: 120 }}>
+                        <InputLabel id="variable-select-label">Variable</InputLabel>
+                        <Select
+                            labelId="variable-select-label"
+                            value={selectedVariable}
+                            label="Variable"
+                            onChange={(e) => setSelectedVariable(e.target.value as VariableKey)}
+                        >
+                            {Object.entries(VARIABLES).map(([key, value]) => (
+                                <MenuItem key={key} value={key}>
+                                    {value.title}
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </FormControl>
+                    <FormControl sx={{ m: 1, minWidth: 120 }}>
+                        <InputLabel id="colormap-select-label">Colormap</InputLabel>
+                        <Select
+                            labelId="colormap-select-label"
+                            value={colormap}
+                            label="Colormap"
+                            onChange={(e) => setColormap(e.target.value as typeof COLORMAPS[number])}
+                        >
+                            {COLORMAPS.map((cm) => (
+                                <MenuItem key={cm} value={cm}>
+                                    {cm.charAt(0).toUpperCase() + cm.slice(1)}
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </FormControl>
+                </Box>
                 <Box sx={{ height: '100%', flexDirection: "column", flexWrap: "nowrap", flexGrow: 1, position: "relative" }} id="map">
                     <Map
                         ref={mapRef}
@@ -105,14 +172,14 @@ const MapboxMap = forwardRef<MapRef | null, MapProps>(
                         )}
                         <MapLegend 
                             colormap={colormap}
-                            min={1.18}
-                            max={35.19}
-                            title="Temperature (°C)"
+                            min={parseFloat(VARIABLES[selectedVariable].rescale.split(',')[0])}
+                            max={parseFloat(VARIABLES[selectedVariable].rescale.split(',')[1])}
+                            title={VARIABLES[selectedVariable].title}
                         />
                     </Map>
                 </Box>
-        </Grid>
-    )
+            </Grid>
+        )
     }
 )
 

--- a/app/components/Data-Explorer/Map.tsx
+++ b/app/components/Data-Explorer/Map.tsx
@@ -41,6 +41,8 @@ type VariableKey = keyof typeof VARIABLES;
 
 const COLORMAPS = ["magma", "viridis", "inferno", "plasma", "cividis"] as const;
 
+const GWL_VALUES = ["1.5", "2.0", "2.5", "3.0"] as const;
+
 const MapboxMap = forwardRef<MapRef | null, MapProps>(
     ({ metricSelected, gwlSelected, data, setMetricSelected, setGwlSelected }, ref) => {
         const mapRef = useRef<MapRef | null>(null)
@@ -49,6 +51,7 @@ const MapboxMap = forwardRef<MapRef | null, MapProps>(
         const [mounted, setMounted] = useState(false)
         const [colormap, setColormap] = useState<typeof COLORMAPS[number]>("magma")
         const [selectedVariable, setSelectedVariable] = useState<VariableKey>("TX99p")
+        const [selectedGwl, setSelectedGwl] = useState<typeof GWL_VALUES[number]>("3.0")
 
         const initialViewState = {
             longitude: -120,
@@ -74,7 +77,7 @@ const MapboxMap = forwardRef<MapRef | null, MapProps>(
                 const params = {
                     url: VARIABLES[selectedVariable].path,
                     variable: selectedVariable,
-                    datetime: "3.0",  // Hardcoded
+                    datetime: selectedGwl,
                     rescale: VARIABLES[selectedVariable].rescale,
                     colormap_name: colormap
                 };
@@ -100,7 +103,7 @@ const MapboxMap = forwardRef<MapRef | null, MapProps>(
             };
 
             fetchTileJson();
-        }, [metricSelected, gwlSelected, colormap, selectedVariable]);
+        }, [metricSelected, selectedGwl, colormap, selectedVariable]);
 
         // Handle hydration mismatch
         useEffect(() => {
@@ -115,8 +118,8 @@ const MapboxMap = forwardRef<MapRef | null, MapProps>(
         return (
             <Grid container sx={{ height: '100%', flexDirection: "column", flexWrap: "nowrap", flexGrow: 1 }}>
                 <Box>
-                    <p>{metricSelected}</p>
-                    <p>{gwlSelected}</p>
+                    {/* <p>{metricSelected}</p>
+                    <p>{gwlSelected}</p> */}
                     <FormControl sx={{ m: 1, minWidth: 120 }}>
                         <InputLabel id="variable-select-label">Variable</InputLabel>
                         <Select
@@ -128,6 +131,21 @@ const MapboxMap = forwardRef<MapRef | null, MapProps>(
                             {Object.entries(VARIABLES).map(([key, value]) => (
                                 <MenuItem key={key} value={key}>
                                     {value.title}
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </FormControl>
+                    <FormControl sx={{ m: 1, minWidth: 120 }}>
+                        <InputLabel id="gwl-select-label">GWL</InputLabel>
+                        <Select
+                            labelId="gwl-select-label"
+                            value={selectedGwl}
+                            label="GWL"
+                            onChange={(e) => setSelectedGwl(e.target.value as typeof GWL_VALUES[number])}
+                        >
+                            {GWL_VALUES.map((gwl) => (
+                                <MenuItem key={gwl} value={gwl}>
+                                    {gwl}°C
                                 </MenuItem>
                             ))}
                         </Select>

--- a/app/components/Data-Explorer/Map.tsx
+++ b/app/components/Data-Explorer/Map.tsx
@@ -5,13 +5,14 @@ import '@mapbox/mapbox-gl-geocoder/dist/mapbox-gl-geocoder.css'
 import '@/app/styles/dashboard/mapbox-map.scss'
 import React, { useState, useEffect, useRef, forwardRef, useImperativeHandle } from 'react'
 import { Map, MapRef, Layer, Source, MapMouseEvent, NavigationControl, ScaleControl, LngLatBoundsLike } from 'react-map-gl'
+import { throttle } from 'lodash'
 import Box from '@mui/material/Box'
 import Grid from '@mui/material/Unstable_Grid2'
 import { MapLegend } from './MapLegend'
-import LoadingSpinner from '../Global/LoadingSpinner'
-import { throttle, debounce } from 'lodash'
-import GeocoderControl from '../Solar-Drought-Visualizer/geocoder-control'
 import { MapPopup } from './MapPopup'
+import LoadingSpinner from '../Global/LoadingSpinner'
+import GeocoderControl from '../Solar-Drought-Visualizer/geocoder-control'
+
 
 // remove me, for demo only v
 import Select from '@mui/material/Select'
@@ -207,6 +208,8 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
             };
         }, []);
 
+        const isLoading = !mounted || !tileJson;
+
         if (!mounted) {
             return (
                 <Grid container sx={{ height: '100%', flexDirection: "column", flexWrap: "nowrap", flexGrow: 1 }}>
@@ -229,7 +232,7 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
         }
 
         return (
-            <Grid container sx={{ height: '100%', flexDirection: "column", flexWrap: "nowrap", flexGrow: 1 }}>
+            <Grid container sx={{ height: '100%', flexDirection: "column", flexWrap: "nowrap", flexGrow: 1, position: 'relative' }}>
                 {/* remove v */}
                 <Box>
                     {/* <p>{metricSelected}</p>
@@ -270,19 +273,25 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
                     </FormControl>
                 </Box>
                 {/* remove ^ */}
+
                 <Box sx={{ height: '100%', position: 'relative' }} id="map">
-                    {!tileJson && (
-                        <Box sx={{ 
-                            position: 'absolute', 
-                            top: '50%', 
-                            left: '50%', 
-                            transform: 'translate(-50%, -50%)',
-                            zIndex: 3
-                        }}>
-                            <LoadingSpinner />
-                        </Box>
-                    )}
                     <div style={{ position: 'relative', width: '100%', height: '100%' }}>
+                        {isLoading && (
+                            <Box sx={{ 
+                                position: 'absolute', 
+                                top: 0,
+                                left: 0,
+                                right: 0,
+                                bottom: 0,
+                                display: 'flex',
+                                alignItems: 'center',
+                                justifyContent: 'center',
+                                backgroundColor: 'rgba(255, 255, 255, 0.5)',
+                                zIndex: 9999
+                            }}>
+                                <LoadingSpinner />
+                            </Box>
+                        )}
                         <Map
                             ref={mapRef}
                             onLoad={handleMapLoad}

--- a/app/components/Data-Explorer/Map.tsx
+++ b/app/components/Data-Explorer/Map.tsx
@@ -10,6 +10,7 @@ import Select from '@mui/material/Select'
 import MenuItem from '@mui/material/MenuItem'
 import FormControl from '@mui/material/FormControl'
 import InputLabel from '@mui/material/InputLabel'
+import LoadingSpinner from '../Global/LoadingSpinner'
 
 type MapProps = {
     metricSelected: number;
@@ -167,19 +168,21 @@ const MapboxMap = forwardRef<MapRef | null, MapProps>(
                     </FormControl>
                 </Box>
                 <Box sx={{ height: '100%', flexDirection: "column", flexWrap: "nowrap", flexGrow: 1, position: "relative" }} id="map">
-                    <Map
-                        ref={mapRef}
-                        onLoad={handleMapLoad}
-                        mapboxAccessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN}
-                        initialViewState={initialViewState}
-                        mapStyle="mapbox://styles/mapbox/streets-v9"
-                        scrollZoom={false}
-                        minZoom={3.5}
-                        style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }}
-                    >
-                        <NavigationControl position="bottom-left" />
-                        <ScaleControl position="bottom-right" maxWidth={100} unit="metric" />
-                        {tileJson && (
+                    {!tileJson ? (
+                        <LoadingSpinner />
+                    ) : (
+                        <Map
+                            ref={mapRef}
+                            onLoad={handleMapLoad}
+                            mapboxAccessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN}
+                            initialViewState={initialViewState}
+                            mapStyle="mapbox://styles/mapbox/streets-v9"
+                            scrollZoom={false}
+                            minZoom={3.5}
+                            style={{ position: "absolute", top: 0, left: 0, right: 0, bottom: 0 }}
+                        >
+                            <NavigationControl position="bottom-left" />
+                            <ScaleControl position="bottom-right" maxWidth={100} unit="metric" />
                             <Source type="raster" tiles={tileJson.tiles} tileSize={256}>
                                 <Layer
                                     id="tile-layer"
@@ -187,14 +190,14 @@ const MapboxMap = forwardRef<MapRef | null, MapProps>(
                                     paint={{ 'raster-opacity': 0.8 }}
                                 />
                             </Source>
-                        )}
-                        <MapLegend 
-                            colormap={colormap}
-                            min={parseFloat(VARIABLES[selectedVariable].rescale.split(',')[0])}
-                            max={parseFloat(VARIABLES[selectedVariable].rescale.split(',')[1])}
-                            title={VARIABLES[selectedVariable].title}
-                        />
-                    </Map>
+                            <MapLegend 
+                                colormap={colormap}
+                                min={parseFloat(VARIABLES[selectedVariable].rescale.split(',')[0])}
+                                max={parseFloat(VARIABLES[selectedVariable].rescale.split(',')[1])}
+                                title={VARIABLES[selectedVariable].title}
+                            />
+                        </Map>
+                    )}
                 </Box>
             </Grid>
         )

--- a/app/components/Data-Explorer/Map.tsx
+++ b/app/components/Data-Explorer/Map.tsx
@@ -98,12 +98,15 @@ const MapboxMap = forwardRef<MapRef | null, MapProps>(
                     const gwlIndex = GWL_VALUES.indexOf(selectedGwl);
                     const value = data.data[gwlIndex];
                     
-                    if (value !== undefined) {
+                    // Only set hover info if we have a valid value
+                    if (value !== undefined && value !== null) {
                         setHoverInfo({
                             longitude: lng,
                             latitude: lat,
                             value: value
                         });
+                    } else {
+                        setHoverInfo(null);
                     }
                 }
             } catch (error) {

--- a/app/components/Data-Explorer/MapLegend.tsx
+++ b/app/components/Data-Explorer/MapLegend.tsx
@@ -1,0 +1,102 @@
+import * as d3 from 'd3'
+import React, { useEffect, useRef } from 'react'
+import Box from '@mui/material/Box'
+import Typography from '@mui/material/Typography'
+import Paper from '@mui/material/Paper'
+
+
+type MapLegendProps = {
+    colormap: string;
+    min: number;
+    max: number;
+    width?: number;
+    height?: number;
+    title?: string;
+}
+
+const LEGEND_MARGIN = { top: 20, right: 0, bottom: 20, left: 0 }
+const LABEL_MARGIN = 16
+
+export const MapLegend = ({
+    colormap,
+    min,
+    max,
+    width = 440,
+    height = 124
+}: MapLegendProps) => {
+    const canvasRef = useRef<HTMLCanvasElement>(null)
+
+    const boundsWidth = width - LEGEND_MARGIN.right - LEGEND_MARGIN.left - (2 * LABEL_MARGIN)
+    const boundsHeight = 24
+
+    const xScale = d3.scaleLinear()
+        .range([LABEL_MARGIN, boundsWidth + LABEL_MARGIN])
+        .domain([min, max])
+
+    const interpolatorKey = `interpolate${colormap.charAt(0).toUpperCase() + colormap.slice(1)}` as keyof typeof d3
+    const interpolator = d3[interpolatorKey] as (t: number) => string
+    const colorScale = d3.scaleSequential<string>()
+        .domain([min, max])
+        .interpolator(interpolator)
+
+    const allTicks = [min, ...xScale.ticks(4), max].map((tick, idx) => {
+        return (
+            <React.Fragment key={`tick-${idx}`}>
+                <line
+                    x1={xScale(tick)}
+                    x2={xScale(tick)}
+                    y1={0}
+                    y2={boundsHeight + 10}
+                    stroke='black'
+                />
+                <text
+                    x={xScale(tick)}
+                    y={boundsHeight + 20}
+                    fontSize={12}
+                    textAnchor='middle'
+                >
+                    {tick}
+                </text>
+            </React.Fragment>
+        )
+    })
+
+    useEffect(() => {
+        const canvas = canvasRef.current
+        const context = canvas?.getContext('2d')
+
+        if (!context) return
+
+        for (let i = 0; i < boundsWidth; i++) {
+            context.fillStyle = colorScale(min + (max - min) * (i / boundsWidth))
+            context.fillRect(i + LABEL_MARGIN, 0, 1, boundsHeight)
+        }
+    }, [width, height, colorScale, min, max, boundsWidth, boundsHeight])
+
+    return (
+        <Paper sx={{ 
+            position: 'absolute',
+            bottom: 40,
+            left: '50%',
+            transform: 'translateX(-50%)',
+            backgroundColor: 'white',
+            padding: 2,
+            boxShadow: 0,
+            borderRadius: 1
+        }}>
+            <div style={{ position: 'relative' }}>
+                <canvas ref={canvasRef} width={boundsWidth + (2 * LABEL_MARGIN)} height={boundsHeight} />
+                <svg
+                    width={boundsWidth + (2 * LABEL_MARGIN)}
+                    height={boundsHeight + 30}
+                    style={{ position: 'absolute', top: 0, left: 0 }}
+                >
+                    {allTicks}
+                </svg>
+            </div>
+            <Typography variant="subtitle2" sx={{ mt: 3, textAlign: 'center' }}>
+                Legend Title
+            </Typography>
+        </Paper>
+    )
+}

--- a/app/components/Data-Explorer/MapLegend.tsx
+++ b/app/components/Data-Explorer/MapLegend.tsx
@@ -4,14 +4,13 @@ import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
 import Paper from '@mui/material/Paper'
 
-
 type MapLegendProps = {
-    colormap: string;
-    min: number;
-    max: number;
-    width?: number;
-    height?: number;
-    title?: string;
+    colormap: string
+    min: number
+    max: number
+    width?: number
+    height?: number
+    title?: string
 }
 
 const LEGEND_MARGIN = { top: 20, right: 0, bottom: 20, left: 0 }

--- a/app/components/Data-Explorer/MapLegend.tsx
+++ b/app/components/Data-Explorer/MapLegend.tsx
@@ -22,7 +22,8 @@ export const MapLegend = ({
     min,
     max,
     width = 440,
-    height = 124
+    height = 124,
+    title
 }: MapLegendProps) => {
     const canvasRef = useRef<HTMLCanvasElement>(null)
 
@@ -75,10 +76,6 @@ export const MapLegend = ({
 
     return (
         <Paper sx={{ 
-            position: 'absolute',
-            bottom: 40,
-            left: '50%',
-            transform: 'translateX(-50%)',
             backgroundColor: 'white',
             padding: 2,
             boxShadow: 0,
@@ -95,7 +92,7 @@ export const MapLegend = ({
                 </svg>
             </div>
             <Typography variant="subtitle2" sx={{ mt: 3, textAlign: 'center' }}>
-                Legend Title
+                {title}
             </Typography>
         </Paper>
     )

--- a/app/components/Data-Explorer/MapLegend.tsx
+++ b/app/components/Data-Explorer/MapLegend.tsx
@@ -81,7 +81,7 @@ export const MapLegend = ({
             boxShadow: 0,
             borderRadius: 1
         }}>
-            <div style={{ position: 'relative' }}>
+            <Box style={{ position: 'relative' }}>
                 <canvas ref={canvasRef} width={boundsWidth + (2 * LABEL_MARGIN)} height={boundsHeight} />
                 <svg
                     width={boundsWidth + (2 * LABEL_MARGIN)}
@@ -90,7 +90,7 @@ export const MapLegend = ({
                 >
                     {allTicks}
                 </svg>
-            </div>
+            </Box>
             <Typography variant="subtitle2" sx={{ mt: 3, textAlign: 'center' }}>
                 {title}
             </Typography>

--- a/app/components/Data-Explorer/MapPopup.tsx
+++ b/app/components/Data-Explorer/MapPopup.tsx
@@ -1,0 +1,24 @@
+import { Popup } from 'react-map-gl'
+import Typography from '@mui/material/Typography'
+
+type MapPopupProps = {
+    longitude: number;
+    latitude: number;
+    value: number;
+}
+
+export const MapPopup = ({ longitude, latitude, value }: MapPopupProps) => {
+    return (
+        <Popup
+            longitude={longitude}
+            latitude={latitude}
+            closeButton={false}
+            anchor="bottom"
+            className="map-popup"
+        >
+            <Typography variant="body2">
+                {value.toFixed(2)}
+            </Typography>
+        </Popup>
+    )
+} 

--- a/app/components/Data-Explorer/MapPopup.tsx
+++ b/app/components/Data-Explorer/MapPopup.tsx
@@ -2,9 +2,9 @@ import { Popup } from 'react-map-gl'
 import Typography from '@mui/material/Typography'
 
 type MapPopupProps = {
-    longitude: number;
-    latitude: number;
-    value: number;
+    longitude: number
+    latitude: number
+    value: number
 }
 
 export const MapPopup = ({ longitude, latitude, value }: MapPopupProps) => {

--- a/app/components/Solar-Drought-Visualizer/geocoder-control.tsx
+++ b/app/components/Solar-Drought-Visualizer/geocoder-control.tsx
@@ -23,7 +23,7 @@ export default function GeocoderControl(props: GeocoderControlProps) {
 
   const [marker, setMarker] = useState(null);
 
-  const geocoder = useControl<MapboxGeocoder>(
+  const geocoder = useControl<any>(
     () => {
       const ctrl = new MapboxGeocoder({
         ...props,

--- a/app/components/Solar-Drought-Visualizer/geocoder-control.tsx
+++ b/app/components/Solar-Drought-Visualizer/geocoder-control.tsx
@@ -3,6 +3,14 @@ import {useState} from 'react';
 import {useControl, Marker, MarkerProps, ControlPosition} from 'react-map-gl';
 import MapboxGeocoder, {GeocoderOptions} from '@mapbox/mapbox-gl-geocoder';
 
+type GeocoderResult = {
+    center?: [number, number];
+    geometry?: {
+        type: string;
+        coordinates: [number, number];
+    };
+};
+
 type GeocoderControlProps = Omit<GeocoderOptions, 'accessToken' | 'mapboxgl' | 'marker'> & {
   mapboxAccessToken: string;
   marker?: boolean | Omit<MarkerProps, 'longitude' | 'latitude'>;
@@ -13,7 +21,7 @@ type GeocoderControlProps = Omit<GeocoderOptions, 'accessToken' | 'mapboxgl' | '
 
   onLoading?: (e: object) => void;
   onResults?: (e: object) => void;
-  onResult?: (e: object) => void;
+  onResult?: (e: { result: GeocoderResult }) => void;
   onError?: (e: object) => void;
 
 };

--- a/app/styles/dashboard/mapbox-map.scss
+++ b/app/styles/dashboard/mapbox-map.scss
@@ -4,10 +4,24 @@
     flex-direction: column;
     gap: 15px;
   }
+}
 
-  &-text {
-    display: flex;
-    flex-direction: column;
-  }
+.mapboxgl-ctrl-geocoder.mapboxgl-ctrl {
+    // so geocoder component has same styling as navigation component
+    box-shadow: rgba(0, 0, 0, 0.1) 0px 0px 0px 2px;
+}
+
+.mapboxgl-popup.map-popup {
+    .mapboxgl-popup-content {
+        background-color: white;
+        border: 0;
+        border-radius: 4px;
+        padding: 8px 16px;
+        box-shadow: none;
+    }
+
+    .mapboxgl-popup-tip {
+        border-top-color:  white;
+    }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@emotion/cache": "^11.11.0",
         "@emotion/react": "^11.11.3",
         "@emotion/styled": "^11.11.0",
-        "@mapbox/mapbox-gl-geocoder": "^5.0.2",
+        "@mapbox/mapbox-gl-geocoder": "^5.0.3",
         "@mui/icons-material": "^5.15.6",
         "@mui/material": "^5.15.6",
         "@turf/turf": "^7.1.0",
@@ -569,11 +569,12 @@
       }
     },
     "node_modules/@mapbox/mapbox-gl-geocoder": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-geocoder/-/mapbox-gl-geocoder-5.0.2.tgz",
-      "integrity": "sha512-o+2atyKKsfbiI2/iutQ/razt5O++kfi9oxwaXSfKc6m/9NudJnQm3rpGB0GagA+becq2NU4U99E9Yzv+UcMCBQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-geocoder/-/mapbox-gl-geocoder-5.0.3.tgz",
+      "integrity": "sha512-aeu2ZM+UKoMUGqqKy4UVVEKsIaNj2KSsiQ4p4YbNSAjZj2vcP33KSod+DPeRwhvoY+MU6KgyvdZ/1xdmH+C62g==",
+      "license": "ISC",
       "dependencies": {
-        "@mapbox/mapbox-sdk": "^0.13.7",
+        "@mapbox/mapbox-sdk": "^0.16.1",
         "events": "^3.3.0",
         "lodash.debounce": "^4.0.6",
         "nanoid": "^3.1.31",
@@ -591,9 +592,10 @@
       "integrity": "sha512-2XghOwu16ZwPJLOFVuIOaLbN0iKMn867evzXFyf0P22dqugezfJwLmdanAgU25ITvz1TvOfVP4jsDImlDJzcWg=="
     },
     "node_modules/@mapbox/mapbox-sdk": {
-      "version": "0.13.7",
-      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-sdk/-/mapbox-sdk-0.13.7.tgz",
-      "integrity": "sha512-JZjBsAVSBv7lX7gQPOQwftBGHIUcvL/tPKFxAL+SCT7u1n+eRH052XebOTkl28pNm7Du6DpKAs1GvgUnDcFFDQ==",
+      "version": "0.16.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-sdk/-/mapbox-sdk-0.16.1.tgz",
+      "integrity": "sha512-dyZrmg+UL/Gp5mGG3CDbcwGSUMYYrfbd9hdp0rcA3pHSf3A9eYoXO9nFiIk6SzBwBVMzHENJz84ZHdqM0MDncQ==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "@mapbox/fusspot": "^0.4.0",
         "@mapbox/parse-mapbox-token": "^0.2.0",
@@ -1106,6 +1108,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -1124,6 +1127,7 @@
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
       "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "license": "MIT",
       "dependencies": {
         "defer-to-connect": "^2.0.0"
       },
@@ -3043,6 +3047,7 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
       "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "license": "MIT",
       "dependencies": {
         "@types/http-cache-semantics": "*",
         "@types/keyv": "^3.1.4",
@@ -3307,7 +3312,8 @@
     "node_modules/@types/http-cache-semantics": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.4.tgz",
-      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA=="
+      "integrity": "sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==",
+      "license": "MIT"
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -3322,6 +3328,7 @@
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
       "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -3337,6 +3344,7 @@
       "resolved": "https://registry.npmjs.org/@types/mapbox__mapbox-gl-geocoder/-/mapbox__mapbox-gl-geocoder-5.0.0.tgz",
       "integrity": "sha512-eGBWdFiP2QgmwndPyhwK6eBeOfyB8vRscp2C6Acqasx5dH8FvTo/VgXWCrCKFR3zkWek/H4w4/CwmBFOs7OLBA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/geojson": "*",
         "@types/mapbox-gl": "*"
@@ -3423,6 +3431,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -4102,6 +4111,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
       "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10.6.0"
       }
@@ -4110,6 +4120,7 @@
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
       "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "license": "MIT",
       "dependencies": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -4270,6 +4281,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
       "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "license": "MIT",
       "dependencies": {
         "mimic-response": "^1.0.0"
       },
@@ -4829,6 +4841,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -4843,6 +4856,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -4859,6 +4873,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       }
@@ -4976,6 +4991,7 @@
       "version": "1.4.4",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -5788,6 +5804,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -5933,6 +5950,7 @@
       "version": "11.8.6",
       "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
       "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4.0.0",
         "@szmarczak/http-timer": "^4.0.5",
@@ -6091,12 +6109,14 @@
     "node_modules/http-cache-semantics": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
-      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ=="
+      "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/http2-wrapper": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
       "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "license": "MIT",
       "dependencies": {
         "quick-lru": "^5.1.1",
         "resolve-alpn": "^1.0.0"
@@ -6865,6 +6885,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -7175,6 +7196,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
       "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -7317,6 +7339,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -7638,9 +7661,10 @@
       "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
     },
     "node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
+      "license": "MIT",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -7689,6 +7713,7 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -8284,7 +8309,8 @@
     "node_modules/resolve-alpn": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
-      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g=="
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -8313,6 +8339,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
       "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "license": "MIT",
       "dependencies": {
         "lowercase-keys": "^2.0.0"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,13 @@
         "@mui/icons-material": "^5.15.6",
         "@mui/material": "^5.15.6",
         "@turf/turf": "^7.1.0",
+        "@types/lodash": "^4.17.14",
         "@types/mapbox-gl": "^3.4.0",
         "client-zip": "^2.4.4",
         "css-loader": "^6.9.0",
         "d3": "^7.9.0",
         "jszip": "^3.10.1",
+        "lodash": "^4.17.21",
         "mapbox-gl": "^3.5.2",
         "next": "14.0.1",
         "react": "^18",
@@ -3323,6 +3325,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-jsxagdikDiDBeIRaPYtArcT8my4tN1og7MtMRquFT3XNA6axxyHDRUemqDz/taRDdOUn0GnGHRCuff4q48sW9A==",
+      "license": "MIT"
     },
     "node_modules/@types/mapbox__mapbox-gl-geocoder": {
       "version": "5.0.0",
@@ -6826,10 +6834,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -16,11 +16,13 @@
     "@mui/icons-material": "^5.15.6",
     "@mui/material": "^5.15.6",
     "@turf/turf": "^7.1.0",
+    "@types/lodash": "^4.17.14",
     "@types/mapbox-gl": "^3.4.0",
     "client-zip": "^2.4.4",
     "css-loader": "^6.9.0",
     "d3": "^7.9.0",
     "jszip": "^3.10.1",
+    "lodash": "^4.17.21",
     "mapbox-gl": "^3.5.2",
     "next": "14.0.1",
     "react": "^18",
@@ -30,8 +32,8 @@
     "url-loader": "^4.1.1"
   },
   "devDependencies": {
-    "@types/mapbox__mapbox-gl-geocoder": "^5.0.0",
     "@types/d3": "^7.4.3",
+    "@types/mapbox__mapbox-gl-geocoder": "^5.0.0",
     "@types/node": "^20",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "@emotion/cache": "^11.11.0",
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
-    "@mapbox/mapbox-gl-geocoder": "^5.0.2",
+    "@mapbox/mapbox-gl-geocoder": "^5.0.3",
     "@mui/icons-material": "^5.15.6",
     "@mui/material": "^5.15.6",
     "@turf/turf": "^7.1.0",


### PR DESCRIPTION
**Desired Outcome**

Mapbox map and map features similar to Figma [Hard Prototype](https://www.figma.com/design/flLvFhladsM9Zchrymd1rn/Cal-Adapt-Data-Explorer-Hard-Prototypes?node-id=100-697&t=LZywdy7VZNqMP653-1) should appear with raster data tiles, a legend, data popups and map controls

**Steps to test**

Load map
- Loading spinner should appear before map loads and before initial raster data tiles appear, if necessary.
- Monochromatic, grayscale map of California should appear
- Initial dataset should appear as raster tiles
- Color ramp should be appropriate
- Legend should appear with appropriate scale and title
- Popups with pixel data values should appear upon hover

Change data variables 
- Raster tiles should change appropriately
- Color ramp should change appropriately
- Legend should change scale and title appropriately
- Popups with pixel data values should appear upon hover

Test map controls
- Geocoding should work
- Map interactions such as zooming, panning, etc. should work
- Map extent is bounded (can't zoom out to vastly intercontinental or global views)

**Notes**
- Map should work with default Cal-Adapt public token
- Map uses custom component GeocoderControl which should be common to all the maps we are currently developing. For now, that component is organized into the Solar Drought Viz directory. Once we have the Data Explorer component merged, I'll create a common component.
- I haven't integrated the tooltips or legend or popup styling. I'd rather leave it to @melijimenez11 if that's okay with them.
- There are a zillion missing tile errors in the console logs. I have to write some additional code to set the bounds of the raster tiles that are requested, but I'll have to query the bounds from the api, translate the crs, and then filter. I'd rather create this pull request now so that I'm not blocking @melijimenez11. This issue isn't affecting the in-browser functionality -- just making a mess in the console.



