### PR TITLE
fix/make sure map is loaded before loading raster layer tiles

### DIFF
--- a/app/components/Data-Explorer/Map.tsx
+++ b/app/components/Data-Explorer/Map.tsx
@@ -350,7 +350,7 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
                             onError={handleMapError}
                             aria-label="Map"
                         >
-                            {tileJson && (
+                            {mapLoaded && tileJson && (
                                 <Source 
                                     id="raster-source"
                                     type="raster"


### PR DESCRIPTION
We were getting intermittent get() errors. This is a fix to make sure the map is loaded before loading the raster data tiles.

**Desired Outcome**

The data explorer should not trigger `get()` errors on load.

`Steps to test`

Clear cache and load the Data Explorer. The error is intermittent and dependent on the timing of the basemap loading. 