### PR TITLE
Data explorer gwl fix

### DIFF
--- a/app/components/Data-Explorer/DataExplorer.tsx
+++ b/app/components/Data-Explorer/DataExplorer.tsx
@@ -1,12 +1,13 @@
 'use client'
 
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect } from 'react'
 
 import MapboxMap from './Map'
 import Grid from '@mui/material/Unstable_Grid2'
 import MapUI from './MapUI'
 
 import { useLeftDrawer } from '../../context/LeftDrawerContext'
+import { globalWarmingLevelsList } from '@/app/lib/data-explorer/global-warming-levels'
 
 type DataExplorerProps = {
     data: any;
@@ -28,8 +29,20 @@ export default function DataExplorer({ data }: DataExplorerProps) {
 
     return (
         <Grid container sx={{ height: '100%', flexDirection: "column", flexWrap: "nowrap", flexGrow: 1 }}>
-            <MapUI metricSelected={metricSelected} gwlSelected={gwlSelected} setMetricSelected={setMetricSelected} setGwlSelected={setGwlSelected}></MapUI>
-            <MapboxMap gwlSelected={gwlSelected} setGwlSelected={setGwlSelected} metricSelected={metricSelected} setMetricSelected={setMetricSelected} data={data}></MapboxMap>
+            <MapUI
+                metricSelected={metricSelected}
+                gwlSelected={gwlSelected}
+                setMetricSelected={setMetricSelected}
+                setGwlSelected={setGwlSelected}
+                globalWarmingLevels={globalWarmingLevelsList}
+            />
+            <MapboxMap
+                gwlSelected={gwlSelected}
+                setGwlSelected={setGwlSelected}
+                metricSelected={metricSelected}
+                setMetricSelected={setMetricSelected}
+                globalWarmingLevels={globalWarmingLevelsList}
+            />
         </Grid>
     )
 }

--- a/app/components/Data-Explorer/DataExplorer.tsx
+++ b/app/components/Data-Explorer/DataExplorer.tsx
@@ -8,6 +8,7 @@ import MapUI from './MapUI'
 
 import { useLeftDrawer } from '../../context/LeftDrawerContext'
 import { globalWarmingLevelsList } from '@/app/lib/data-explorer/global-warming-levels'
+import { metricsList } from '@/app/lib/data-explorer/metrics'
 
 type DataExplorerProps = {
     data: any;
@@ -35,6 +36,7 @@ export default function DataExplorer({ data }: DataExplorerProps) {
                 setMetricSelected={setMetricSelected}
                 setGwlSelected={setGwlSelected}
                 globalWarmingLevels={globalWarmingLevelsList}
+                metrics={metricsList}
             />
             <MapboxMap
                 gwlSelected={gwlSelected}
@@ -42,6 +44,7 @@ export default function DataExplorer({ data }: DataExplorerProps) {
                 metricSelected={metricSelected}
                 setMetricSelected={setMetricSelected}
                 globalWarmingLevels={globalWarmingLevelsList}
+                metrics={metricsList}
             />
         </Grid>
     )

--- a/app/components/Data-Explorer/Map.tsx
+++ b/app/components/Data-Explorer/Map.tsx
@@ -160,6 +160,10 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
                     .join('&')
 
                 const url = `${BASE_URL}/WebMercatorQuad/tilejson.json?${queryString}`
+                
+
+                // debug: log the request url
+                console.log('Fetching TileJSON with url:', url)
 
                 try {
                     const response = await fetch(url)

--- a/app/components/Data-Explorer/Map.tsx
+++ b/app/components/Data-Explorer/Map.tsx
@@ -113,6 +113,7 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
         // Refs
         const mapRef = useRef<MapRef | null>(null)
         const mapContainerRef = useRef<HTMLDivElement | null>(null) // Reference to the map container
+        const initialLoadRef = useRef(true)
 
         // Forward the internal ref to the parent
         useImperativeHandle(ref, () => mapRef.current || undefined)
@@ -146,6 +147,11 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
         const currentColormap = currentVariableData.colormap
 
         useEffect(() => {
+            if (initialLoadRef.current) {
+                initialLoadRef.current = false;
+                return; // Skip the first execution
+            }
+
             const fetchTileJson = async () => {
                 const params = {
                     url: currentVariableData.path,

--- a/app/components/Data-Explorer/Map.tsx
+++ b/app/components/Data-Explorer/Map.tsx
@@ -33,7 +33,6 @@ const RASTER_TILE_LAYER_OPACITY = 0.8 as const
 type MapProps = {
     metricSelected: number
     gwlSelected: number
-    data: Record<string, unknown>
     setMetricSelected: (metric: number) => void
     setGwlSelected: (gwl: number) => void
     globalWarmingLevels: { id: number; value: string }[]
@@ -144,7 +143,7 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
                 
 
                 // debug: log the request url
-                console.log('Fetching TileJSON with url:', url)
+                // console.log('Fetching TileJSON with url:', url)
 
                 try {
                     const response = await fetch(url)

--- a/app/components/Data-Explorer/Map.tsx
+++ b/app/components/Data-Explorer/Map.tsx
@@ -278,17 +278,6 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
             if (!e.target) return
             mapRef.current = e.target as unknown as MapRef
             setMapLoaded(true)
-
-            const mapContainer = document.getElementById('map')
-
-            if (mapContainer) {
-                const resizeObserver = new ResizeObserver(() => {
-                    if (mapRef.current) {
-                        mapRef.current.resize() // Resize the map when the container changes
-                    }
-                })
-                resizeObserver.observe(mapContainer)
-            }
         }
 
         return (

--- a/app/components/Data-Explorer/Map.tsx
+++ b/app/components/Data-Explorer/Map.tsx
@@ -61,6 +61,7 @@ type MapProps = {
     data: Record<string, unknown>
     setMetricSelected: (metric: number) => void
     setGwlSelected: (gwl: number) => void
+    globalWarmingLevels: { id: number; title: string }[]
 }
 
 type VariableKey = keyof typeof VARIABLES
@@ -109,7 +110,7 @@ const throttledFetchPoint = throttle(async (
 })
 
 const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
-    ({ metricSelected, gwlSelected, data, setMetricSelected, setGwlSelected }, ref) => {
+    ({ metricSelected, gwlSelected, data, setMetricSelected, setGwlSelected, globalWarmingLevels }, ref) => {
         // Refs
         const mapRef = useRef<MapRef | null>(null)
         const mapContainerRef = useRef<HTMLDivElement | null>(null) // Reference to the map container

--- a/app/components/Data-Explorer/MapUI.tsx
+++ b/app/components/Data-Explorer/MapUI.tsx
@@ -37,7 +37,6 @@ const MenuProps: any = {
             width: 250,
         },
     },
-    getContentAnchorEl: null,
     anchorOrigin: {
         vertical: "bottom",
         horizontal: "center"

--- a/app/components/Data-Explorer/MapUI.tsx
+++ b/app/components/Data-Explorer/MapUI.tsx
@@ -27,7 +27,7 @@ type MapUIProps = {
     gwlSelected: number;
     setMetricSelected: (metric: number) => void;
     setGwlSelected: (gwl: number) => void;
-    globalWarmingLevels: { id: number; title: string }[];
+    globalWarmingLevels: { id: number; value: string }[];
 }
 
 const MenuProps: any = {
@@ -104,11 +104,10 @@ export default function Map({ metricSelected, gwlSelected, setMetricSelected, se
                                                 }}
                                                 MenuProps={MenuProps}
                                                 sx={{ mt: '15px', width: '200px' }}
-
                                             >
                                                 {globalWarmingLevels.map((gwl) => (
                                                     <MenuItem key={gwl.id} value={gwl.id}>
-                                                        <ListItemText primary={gwl.title} />
+                                                        <ListItemText primary={`${gwl.value}°`} />
                                                     </MenuItem>
                                                 ))}
                                             </Select>

--- a/app/components/Data-Explorer/MapUI.tsx
+++ b/app/components/Data-Explorer/MapUI.tsx
@@ -65,9 +65,6 @@ export default function MapUI({ metricSelected, gwlSelected, setMetricSelected, 
     const helpOpen = Boolean(helpAnchorEl);
     const id = helpOpen ? 'simple-popover' : undefined;
 
-    // Use globalWarmingLevels as needed in MapUI
-    console.log('globalWarmingLevels in MapUI:', globalWarmingLevels);
-
     return (
         <div className="map-ui" style={{
             width: open ? `calc(100% - ${drawerWidth}px + 72px)` : '100%',

--- a/app/components/Data-Explorer/MapUI.tsx
+++ b/app/components/Data-Explorer/MapUI.tsx
@@ -16,7 +16,6 @@ import Fade from '@mui/material/Fade'
 import Fab from '@mui/material/Fab'
 import QuestionMarkOutlinedIcon from '@mui/icons-material/QuestionMarkOutlined';
 
-import { metricsList } from '@/app/lib/data-explorer/metrics'
 import { useLeftDrawer } from '../../context/LeftDrawerContext'
 
 const ITEM_HEIGHT = 48;
@@ -28,6 +27,7 @@ type MapUIProps = {
     setMetricSelected: (metric: number) => void;
     setGwlSelected: (gwl: number) => void;
     globalWarmingLevels: { id: number; value: string }[];
+    metrics: { id: number; title: string; variable: string; description: string; path: string; rescale: string; colormap: string }[];
 }
 
 const MenuProps: any = {
@@ -49,7 +49,7 @@ const MenuProps: any = {
 }
 
 
-export default function Map({ metricSelected, gwlSelected, setMetricSelected, setGwlSelected, globalWarmingLevels }: MapUIProps) {
+export default function MapUI({ metricSelected, gwlSelected, setMetricSelected, setGwlSelected, globalWarmingLevels, metrics }: MapUIProps) {
     const { open, drawerWidth } = useLeftDrawer()
 
     const [helpAnchorEl, setHelpAnchorEl] = React.useState<HTMLButtonElement | null>(null)
@@ -139,9 +139,8 @@ export default function Map({ metricSelected, gwlSelected, setMetricSelected, se
                                                 }}
                                                 MenuProps={MenuProps}
                                                 sx={{ mt: '15px', width: '220px' }}
-
                                             >
-                                                {metricsList.map((metric) => (
+                                                {metrics.map((metric) => (
                                                     <MenuItem key={metric.id} value={metric.id}>
                                                         <ListItemText primary={metric.title} />
                                                     </MenuItem>

--- a/app/components/Data-Explorer/MapUI.tsx
+++ b/app/components/Data-Explorer/MapUI.tsx
@@ -17,7 +17,6 @@ import Fab from '@mui/material/Fab'
 import QuestionMarkOutlinedIcon from '@mui/icons-material/QuestionMarkOutlined';
 
 import { metricsList } from '@/app/lib/data-explorer/metrics'
-import { globalWarmingLevelsList } from '@/app/lib/data-explorer/global-warming-levels'
 import { useLeftDrawer } from '../../context/LeftDrawerContext'
 
 const ITEM_HEIGHT = 48;
@@ -28,6 +27,7 @@ type MapUIProps = {
     gwlSelected: number;
     setMetricSelected: (metric: number) => void;
     setGwlSelected: (gwl: number) => void;
+    globalWarmingLevels: { id: number; title: string }[];
 }
 
 const MenuProps: any = {
@@ -49,7 +49,7 @@ const MenuProps: any = {
 }
 
 
-export default function Map({ metricSelected, gwlSelected, setMetricSelected, setGwlSelected}: MapUIProps) {
+export default function Map({ metricSelected, gwlSelected, setMetricSelected, setGwlSelected, globalWarmingLevels }: MapUIProps) {
     const { open, drawerWidth } = useLeftDrawer()
 
     const [helpAnchorEl, setHelpAnchorEl] = React.useState<HTMLButtonElement | null>(null)
@@ -64,6 +64,9 @@ export default function Map({ metricSelected, gwlSelected, setMetricSelected, se
 
     const helpOpen = Boolean(helpAnchorEl);
     const id = helpOpen ? 'simple-popover' : undefined;
+
+    // Use globalWarmingLevels as needed in MapUI
+    console.log('globalWarmingLevels in MapUI:', globalWarmingLevels);
 
     return (
         <div className="map-ui" style={{
@@ -103,7 +106,7 @@ export default function Map({ metricSelected, gwlSelected, setMetricSelected, se
                                                 sx={{ mt: '15px', width: '200px' }}
 
                                             >
-                                                {globalWarmingLevelsList.map((gwl) => (
+                                                {globalWarmingLevels.map((gwl) => (
                                                     <MenuItem key={gwl.id} value={gwl.id}>
                                                         <ListItemText primary={gwl.title} />
                                                     </MenuItem>

--- a/app/lib/data-explorer/global-warming-levels.tsx
+++ b/app/lib/data-explorer/global-warming-levels.tsx
@@ -1,22 +1,18 @@
 export const globalWarmingLevelsList = [
     {
         "id": 0,
-        "title": 'Current State 1.2°'
-    },
-    {
-        "id": 1,
         "title": '1.5°'
     },
     {
-        "id": 2,
+        "id": 1,
         "title": '2.0°'
     },
     {
-        "id": 3,
+        "id": 2,
         "title": '2.5°'
     },
     {
-        "id": 4,
+        "id": 3,
         "title": '3.0°'
     },
 ]

--- a/app/lib/data-explorer/global-warming-levels.tsx
+++ b/app/lib/data-explorer/global-warming-levels.tsx
@@ -1,18 +1,18 @@
 export const globalWarmingLevelsList = [
     {
         "id": 0,
-        "title": '1.5°'
+        "value": '1.5'
     },
     {
         "id": 1,
-        "title": '2.0°'
+        "value": '2.0'
     },
     {
         "id": 2,
-        "title": '2.5°'
+        "value": '2.5'
     },
     {
         "id": 3,
-        "title": '3.0°'
+        "value": '3.0'
     },
 ]

--- a/app/lib/data-explorer/metrics.tsx
+++ b/app/lib/data-explorer/metrics.tsx
@@ -1,14 +1,29 @@
 export const metricsList = [
     {
         "id": 0, 
-        "title": 'Extreme Heat Days'
+        "title": 'Extreme Heat Days',
+        "variable": 'TX99p',
+        "description": 'Mean annual change in extreme heat days',
+        "path": 's3://cadcat/tmp/era/wrf/cae/mm4mean/ssp370/yr/TX99p/d02/TX99p.zarr',
+        "rescale": '1.18,35.19',
+        "colormap": 'oranges'
     },
     {
         "id": 1, 
-        "title": 'Precipitation'
+        "title": 'Precipitation',
+        "variable": 'R99p',
+        "description": 'Absolute change in 99th percentile 1-day accumulated precipitation',
+        "path": 's3://cadcat/tmp/era/wrf/cae/mm4mean/ssp370/yr/R99p/d02/R99p.zarr',
+        "rescale": '-4.866,39.417',
+        "colormap": 'blues'
     },
     {
         "id": 2, 
-        "title": 'Wildfire'
-    },
+        "title": 'Wildfire',
+        "variable": 'ffwige50',
+        "description": 'Change in median annual number of days with (FFWI) value greater than 50',
+        "path": 's3://cadcat/tmp/era/wrf/cae/mm4mean/ssp370/yr/ffwige50/d02/ffwige50.zarr',
+        "rescale": '-197.96,92.158',
+        "colormap": 'reds'
+    }
 ]


### PR DESCRIPTION
Fixed GWL parameter mismatch between lib list and map component by resetting the globalWarmingLevelsList to match the available GWLs for this dataset. For efficiency, imported both data explorer variable lists (globalWarmingLevelsList & metricsList) into the DataExplorer component and passed them as props to MapUI and Map components. Filled out metricsList object with more properties that can be used in MapUI and are used in Map. Cleaned up unused variables and console logs.

**Desired Outcome & Steps to test**

- Map and MapUI load. Map loads with raster tiles for GWL 1.5C and Extreme Heat Days metric.
- Changing UI dropdown options loads appropriate tiles.

Note that there is debug code in the Map component that logs the request URL so you can check that the appropriate tiles are being requested. If you uncomment this code, you can check that the requests match as well.

