### PR TITLE
Color options

### DIFF
--- a/app/components/Data-Explorer/DataExplorer.tsx
+++ b/app/components/Data-Explorer/DataExplorer.tsx
@@ -29,7 +29,7 @@ export default function DataExplorer({ data }: DataExplorerProps) {
     const [customColorRamp, setCustomColorRamp] = useState<string>('')
 
     const customColorRampList: string[] = [
-        'Inferno', 'BuPu', 'Viridis', 'Cividis', 'Cool', 'Plasma', 'CubehelixDefault', 'PiYG', 'PRGn', 'BrBG', 'PuOr', 'RdGy', 'RdBu',
+        'Inferno', 'BuPu', 'Viridis', 'Cividis', 'Cool', 'Plasma', 'PiYG', 'PRGn', 'BrBG', 'PuOr', 'RdGy', 'RdBu',
         'RdYlBu', 'RdYlGn'
     ]
 
@@ -64,6 +64,7 @@ export default function DataExplorer({ data }: DataExplorerProps) {
                 setMetricSelected={setMetricSelected}
                 globalWarmingLevels={globalWarmingLevelsList}
                 metrics={metricsList}
+                isColorRev={isColorRev}
             />
         </Grid>
     )

--- a/app/components/Data-Explorer/DataExplorer.tsx
+++ b/app/components/Data-Explorer/DataExplorer.tsx
@@ -58,10 +58,8 @@ export default function DataExplorer({ data }: DataExplorerProps) {
             />
             <MapboxMap
                 gwlSelected={gwlSelected}
-                setGwlSelected={setGwlSelected}
                 metricSelected={metricSelected}
                 customColorRamp={customColorRamp}
-                setMetricSelected={setMetricSelected}
                 globalWarmingLevels={globalWarmingLevelsList}
                 metrics={metricsList}
                 isColorRev={isColorRev}

--- a/app/components/Data-Explorer/DataExplorer.tsx
+++ b/app/components/Data-Explorer/DataExplorer.tsx
@@ -19,6 +19,11 @@ export default function DataExplorer({ data }: DataExplorerProps) {
 
     const [gwlSelected, setGwlSelected] = useState<number>(0)
     const [metricSelected, setMetricSelected] = useState<number>(0)
+   
+    // Temp: For reverse color options switch
+    const switchLabel = { inputProps: { 'aria-label': 'Switch color options' } }
+    const [isColorRev, setIsColorRev] = useState<boolean>(false)
+
 
     // TEMP: for color ramp options
     const [customColorRamp, setCustomColorRamp] = useState<string>('')
@@ -48,6 +53,8 @@ export default function DataExplorer({ data }: DataExplorerProps) {
                 globalWarmingLevels={globalWarmingLevelsList}
                 metrics={metricsList}
                 customColorRampList={customColorRampList}
+                isColorRev={isColorRev}
+                setIsColorRev={setIsColorRev}
             />
             <MapboxMap
                 gwlSelected={gwlSelected}

--- a/app/components/Data-Explorer/DataExplorer.tsx
+++ b/app/components/Data-Explorer/DataExplorer.tsx
@@ -24,7 +24,6 @@ export default function DataExplorer({ data }: DataExplorerProps) {
     const switchLabel = { inputProps: { 'aria-label': 'Switch color options' } }
     const [isColorRev, setIsColorRev] = useState<boolean>(false)
 
-
     // TEMP: for color ramp options
     const [customColorRamp, setCustomColorRamp] = useState<string>('')
 

--- a/app/components/Data-Explorer/Map.tsx
+++ b/app/components/Data-Explorer/Map.tsx
@@ -183,7 +183,7 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
         useEffect(() => {
             setCurrentColorMap(currentVariableData.colormap)
         }, [metricSelected])
-        
+
         useEffect(() => {
             if (mapRef.current) {
                 const map = mapRef.current.getMap()

--- a/app/components/Data-Explorer/Map.tsx
+++ b/app/components/Data-Explorer/Map.tsx
@@ -121,6 +121,7 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
 
         // Fetch tiles function
         const fetchTileJson = async () => {
+
             // TEMP: For color wheel options
             let colormap = isColorRev ? currentColorMap.toLowerCase() + '_r' : currentColorMap.toLowerCase()
 
@@ -164,7 +165,7 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
 
         // TEMP: For custom color ramp selector
         useEffect(() => {
-            if (customColorRamp !== '' && customColorRamp !== currentVariableData.colormap) {
+            if (customColorRamp.length > 0 && customColorRamp !== currentVariableData.colormap) {
                 setCurrentColorMap(customColorRamp)
             }
 
@@ -179,6 +180,10 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
             fetchTileJson()
         }, [metricSelected, gwlSelected, currentVariable, currentVariableData, currentGwl, currentColorMap, isColorRev])
 
+        useEffect(() => {
+            setCurrentColorMap(currentVariableData.colormap)
+        }, [metricSelected])
+        
         useEffect(() => {
             if (mapRef.current) {
                 const map = mapRef.current.getMap()
@@ -236,6 +241,11 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
                 }
             )
         }
+
+        // Cleanup throttledFetchPoint
+        useEffect(() => {
+            console.log('currentColorMap changed to: ', currentColorMap)
+        }, [currentColorMap])
 
         // Cleanup throttledFetchPoint
         useEffect(() => {

--- a/app/components/Data-Explorer/Map.tsx
+++ b/app/components/Data-Explorer/Map.tsx
@@ -124,7 +124,7 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
         // Fetch tiles function
         const fetchTileJson = async () => {
             // TEMP: For color wheel options
-            let colormap = currentColorMap.toLowerCase()
+            let colormap = isColorRev ? currentColorMap.toLowerCase() + '_r' : currentColorMap.toLowerCase()
 
             const params = {
                 url: currentVariableData.path,
@@ -174,12 +174,12 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
 
         useEffect(() => {
             if (initialLoadRef.current) {
-                initialLoadRef.current = false;
-                return; // Skip the first execution
+                initialLoadRef.current = false
+                return // Skip the first execution
             }
 
             fetchTileJson()
-        }, [metricSelected, gwlSelected, currentVariable, currentVariableData, currentGwl, currentColorMap])
+        }, [metricSelected, gwlSelected, currentVariable, currentVariableData, currentGwl, currentColorMap, isColorRev])
 
         useEffect(() => {
             if (mapRef.current) {

--- a/app/components/Data-Explorer/Map.tsx
+++ b/app/components/Data-Explorer/Map.tsx
@@ -31,6 +31,7 @@ const BASE_URL = 'https://2fxwkf3nc6.execute-api.us-west-2.amazonaws.com' as con
 const RASTER_TILE_LAYER_OPACITY = 0.8 as const
 
 type MapProps = {
+    isColorRev: boolean
     metricSelected: number
     gwlSelected: number
     customColorRamp: string
@@ -85,7 +86,7 @@ const throttledFetchPoint = throttle(async (
 })
 
 const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
-    ({ metricSelected, gwlSelected, customColorRamp, setMetricSelected, setGwlSelected, globalWarmingLevels, metrics }, ref) => {
+    ({ isColorRev, metricSelected, gwlSelected, customColorRamp, setMetricSelected, setGwlSelected, globalWarmingLevels, metrics }, ref) => {
         // Refs
         const mapRef = useRef<MapRef | null>(null)
         const mapContainerRef = useRef<HTMLDivElement | null>(null) // Reference to the map container
@@ -124,9 +125,6 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
         const fetchTileJson = async () => {
             // TEMP: For color wheel options
             let colormap = currentColorMap.toLowerCase()
-
-            if (colormap == 'CubehelixDefault')
-                colormap = 'cubehelix'
 
             const params = {
                 url: currentVariableData.path,
@@ -383,6 +381,7 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
                                 max={parseFloat(currentVariableData.rescale.split(',')[1])}
                                 title={currentVariableData.description}
                                 aria-label="Map legend"
+                                isColorRev={isColorRev}
                             />
                         </div>
                     </div>

--- a/app/components/Data-Explorer/Map.tsx
+++ b/app/components/Data-Explorer/Map.tsx
@@ -35,8 +35,6 @@ type MapProps = {
     metricSelected: number
     gwlSelected: number
     customColorRamp: string
-    setMetricSelected: (metric: number) => void
-    setGwlSelected: (gwl: number) => void
     globalWarmingLevels: { id: number; value: string }[]
     metrics: { id: number; title: string; variable: string; description: string; path: string; rescale: string; colormap: string }[]
 }
@@ -86,7 +84,7 @@ const throttledFetchPoint = throttle(async (
 })
 
 const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
-    ({ isColorRev, metricSelected, gwlSelected, customColorRamp, setMetricSelected, setGwlSelected, globalWarmingLevels, metrics }, ref) => {
+    ({ isColorRev, metricSelected, gwlSelected, customColorRamp, globalWarmingLevels, metrics }, ref) => {
         // Refs
         const mapRef = useRef<MapRef | null>(null)
         const mapContainerRef = useRef<HTMLDivElement | null>(null) // Reference to the map container
@@ -166,7 +164,7 @@ const MapboxMap = forwardRef<MapRef | undefined, MapProps>(
 
         // TEMP: For custom color ramp selector
         useEffect(() => {
-            if (customColorRamp !== currentVariableData.colormap) {
+            if (customColorRamp !== '' && customColorRamp !== currentVariableData.colormap) {
                 setCurrentColorMap(customColorRamp)
             }
 

--- a/app/components/Data-Explorer/MapLegend.tsx
+++ b/app/components/Data-Explorer/MapLegend.tsx
@@ -13,6 +13,7 @@ type MapLegendProps = {
     width?: number
     height?: number
     title?: string
+    isColorRev: boolean
 }
 
 const LEGEND_MARGIN = { top: 20, right: 0, bottom: 20, left: 0 }
@@ -24,7 +25,8 @@ export const MapLegend = ({
     max,
     width = 520, // adjust this value to make more space for the legend label
     height = 124,
-    title
+    title,
+    isColorRev
 }: MapLegendProps) => {
     const canvasRef = useRef<HTMLCanvasElement>(null)
 
@@ -39,7 +41,7 @@ export const MapLegend = ({
     const interpolator = (d3[interpolatorKey] as (t: number) => string) || d3.interpolateInferno
     const colorScale = d3.scaleSequential<string>()
         .domain([min, max])
-        .interpolator(interpolator)
+        .interpolator(isColorRev ? (t) => interpolator(1-t): interpolator)
 
     const ticks = [min, ...xScale.ticks(4), max]
     const allTicks = ticks.map((tick, idx) => {

--- a/app/components/Data-Explorer/MapUI.tsx
+++ b/app/components/Data-Explorer/MapUI.tsx
@@ -15,7 +15,6 @@ import MenuItem from '@mui/material/MenuItem'
 import Fade from '@mui/material/Fade'
 import Fab from '@mui/material/Fab'
 import QuestionMarkOutlinedIcon from '@mui/icons-material/QuestionMarkOutlined'
-import FormControlLabel from '@mui/material/FormControlLabel'
 import Switch from '@mui/material/Switch'
 
 import { useLeftDrawer } from '../../context/LeftDrawerContext'

--- a/app/components/Data-Explorer/MapUI.tsx
+++ b/app/components/Data-Explorer/MapUI.tsx
@@ -14,7 +14,9 @@ import ListItemText from '@mui/material/ListItemText'
 import MenuItem from '@mui/material/MenuItem'
 import Fade from '@mui/material/Fade'
 import Fab from '@mui/material/Fab'
-import QuestionMarkOutlinedIcon from '@mui/icons-material/QuestionMarkOutlined';
+import QuestionMarkOutlinedIcon from '@mui/icons-material/QuestionMarkOutlined'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import Switch from '@mui/material/Switch'
 
 import { useLeftDrawer } from '../../context/LeftDrawerContext'
 
@@ -22,6 +24,8 @@ const ITEM_HEIGHT = 48;
 const ITEM_PADDING_TOP = 8;
 
 type MapUIProps = {
+    isColorRev: boolean;
+    setIsColorRev: (isColorRev: boolean) => void;
     metricSelected: number;
     gwlSelected: number;
     customColorRamp: string;
@@ -52,7 +56,7 @@ const MenuProps: any = {
 }
 
 
-export default function MapUI({ metricSelected, gwlSelected, customColorRamp, customColorRampList, setCustomColorRamp, setMetricSelected, setGwlSelected, globalWarmingLevels, metrics }: MapUIProps) {
+export default function MapUI({ metricSelected, gwlSelected, customColorRamp, customColorRampList, setCustomColorRamp, setMetricSelected, setGwlSelected, globalWarmingLevels, metrics, isColorRev, setIsColorRev }: MapUIProps) {
     const { open, drawerWidth } = useLeftDrawer()
 
     const [helpAnchorEl, setHelpAnchorEl] = React.useState<HTMLButtonElement | null>(null)
@@ -62,11 +66,12 @@ export default function MapUI({ metricSelected, gwlSelected, customColorRamp, cu
     }
 
     const handleClose = () => {
-        setHelpAnchorEl(null);
+        setHelpAnchorEl(null)
     }
 
     const helpOpen = Boolean(helpAnchorEl);
-    const id = helpOpen ? 'simple-popover' : undefined;
+    const id = helpOpen ? 'simple-popover' : undefined
+
 
     return (
         <div className="map-ui" style={{
@@ -184,6 +189,14 @@ export default function MapUI({ metricSelected, gwlSelected, customColorRamp, cu
                                                 ))}
                                             </Select>
                                         </FormControl>
+                                    </div>
+                                </div>
+                                <div className="container container--transparent">
+                                    <div className="option-group ">
+                                        <div className="option-group__title">
+                                            <Typography variant="body2">Reverse Color Ramp</Typography>
+                                        </div>
+                                        <Switch checked={isColorRev} onChange={() => setIsColorRev(!isColorRev)} />
                                     </div>
                                 </div>
                             </div>

--- a/app/components/Global/Theme Registry/theme.tsx
+++ b/app/components/Global/Theme Registry/theme.tsx
@@ -186,22 +186,6 @@ theme = createTheme(theme, {
 // Override components after creating custom palettes
 theme = createTheme(theme, {
   components: {
-    MuiAlert: {
-      variants: [
-        {
-          props: { variant: 'purple' },
-          style: {
-            backgroundColor: theme.palette.info.main
-          }
-        },
-        {
-          props: { variant: 'grey' },
-          style: {
-            backgroundColor: '#E5ECF6', // Customize the background color
-          },
-        }
-      ]
-    },
     MuiRadio: {
       styleOverrides: {
         root: {

--- a/app/components/Heatmap/Heatmap.tsx
+++ b/app/components/Heatmap/Heatmap.tsx
@@ -69,8 +69,7 @@ export default function Heatmap({ width, height, data, useAltColor, currentColor
         .domain([min, max])
         .interpolator(isColorRev ? (t) => interpolator(1-t): interpolator)
 
-    // **Fallback to prevent colorScale errors**
-    // **Fallback to prevent rendering errors**
+    // Fallback to prevent colorScale errors**
     if (!data) {
         return <div>Loading...</div>;
     }

--- a/app/components/Heatmap/Heatmap.tsx
+++ b/app/components/Heatmap/Heatmap.tsx
@@ -19,6 +19,8 @@ type HeatmapProps = {
     height: number;
     data: any;
     useAltColor: boolean;
+    currentColorMap: string;
+    isColorRev: boolean;
 }
 
 export type InteractionData = {
@@ -29,7 +31,7 @@ export type InteractionData = {
     value: number;
 }
 
-export default function Heatmap({ width, height, data, useAltColor }: HeatmapProps) {
+export default function Heatmap({ width, height, data, useAltColor, currentColorMap, isColorRev }: HeatmapProps) {
     // cell that is being hovered, for tooltips
     const [hoveredCell, setHoveredCell] = useState<InteractionData | null>(null)
 
@@ -38,22 +40,34 @@ export default function Heatmap({ width, height, data, useAltColor }: HeatmapPro
     const min = d3.min(flatData) as number | null ?? 0
     const max = d3.max(flatData) as number | null ?? 1
 
-    const defColorScale = useMemo(() => {
-        return d3
-            .scaleSequential<string>()
-            .interpolator(d3.interpolateRgbBasis(['#FD6A55', '#FEAB7D', '#EEE8DA']))
-            .domain([min ?? 0, max ?? 1]);
-    }, [min, max])
+    /*     const defColorScale = useMemo(() => {
+            return d3
+                .scaleSequential<string>()
+                .interpolator(d3.interpolateRgbBasis(['#FD6A55', '#FEAB7D', '#EEE8DA']))
+                .domain([min ?? 0, max ?? 1]);
+        }, [min, max])
+    
+        const altColorScale = useMemo(() => {
+            return d3
+                .scaleSequential<string>()
+                .interpolator(d3.interpolateRgbBasis(['#e6550d', '#fdae6b', '#fee6ce']))
+                .domain([min ?? 0, max ?? 1]);
+        }, [min, max])
+    
+        // Dynamically select color scale
+        const colorScale = useMemo(() => (useAltColor ? altColorScale : defColorScale), [useAltColor, defColorScale, altColorScale]);
+     */
 
-    const altColorScale = useMemo(() => {
-        return d3
-            .scaleSequential<string>()
-            .interpolator(d3.interpolateRgbBasis(['#e6550d', '#fdae6b', '#fee6ce']))
-            .domain([min ?? 0, max ?? 1]);
-    }, [min, max])
+    // Temp: for color scale selection
 
-    // Dynamically select color scale
-    const colorScale = useMemo(() => (useAltColor ? altColorScale : defColorScale), [useAltColor, defColorScale, altColorScale]);
+    // TEMP: To try out different color maps
+
+    const interpolatorKey = `interpolate${currentColorMap.charAt(0).toUpperCase() + currentColorMap.slice(1)}` as keyof typeof d3
+    const interpolator = (d3[interpolatorKey] as (t: number) => string) || d3.interpolateOranges
+
+    const colorScale = d3.scaleSequential<string>()
+        .domain([min, max])
+        .interpolator(isColorRev ? (t) => interpolator(1-t): interpolator)
 
     // **Fallback to prevent colorScale errors**
     // **Fallback to prevent rendering errors**

--- a/app/components/Solar-Drought-Visualizer/ColorLegend.tsx
+++ b/app/components/Solar-Drought-Visualizer/ColorLegend.tsx
@@ -26,14 +26,11 @@ export const ColorLegend = ({
     const boundsWidth = width - COLOR_LEGEND_MARGIN.right - COLOR_LEGEND_MARGIN.left
     const boundsHeight = height - COLOR_LEGEND_MARGIN.top - COLOR_LEGEND_MARGIN.bottom
 
-
     // Provide default values if min or max is null
     const safeMin = min ?? 0; // default to 0 if min is null
     const safeMax = max ?? 1; // default to 1 if max is null to avoid division by zero
 
     const xScale = d3.scaleLinear().range([0, boundsWidth]).domain([safeMin, safeMax]);
-/*     
-    const xScale = d3.scaleLinear().range([0, boundsWidth]).domain([min, max]) */
 
     const allTicks = xScale.ticks(4).map((tick, idx) => {
         return (
@@ -72,10 +69,6 @@ export const ColorLegend = ({
             context.fillRect(i, 0, 1, boundsHeight);
         }
 
-/*         for (let i = 0; i < boundsWidth; i++) {
-            context.fillStyle = colorScale((max * i) / boundsWidth)
-            context.fillRect(i, 0, 1, boundsHeight)
-        } */
     }, [width, height, colorScale])
 
     return (
@@ -85,7 +78,7 @@ export const ColorLegend = ({
                     position: 'relative',
                     transform: `translate(${COLOR_LEGEND_MARGIN.left}px),
                         ${COLOR_LEGEND_MARGIN.top}px`,
-                        marginBottom: '25px'
+                    marginBottom: '25px'
                 }}
             >
                 <canvas ref={canvasRef} width={boundsWidth} height={boundsHeight} />
@@ -97,7 +90,7 @@ export const ColorLegend = ({
                     {allTicks}
                 </svg>
             </div>
-            <Typography style={{marginLeft: '12px'}} variant="subtitle1">Average number of solar resource drought days</Typography>
+            <Typography style={{ marginLeft: '12px' }} variant="subtitle1">Average number of solar resource drought days</Typography>
         </div>
     )
 }

--- a/app/lib/data-explorer/metrics.tsx
+++ b/app/lib/data-explorer/metrics.tsx
@@ -1,7 +1,7 @@
 export const metricsList = [
     {
         "id": 0, 
-        "title": 'Extreme Heat Days',
+        "title": 'Extreme Heat',
         "variable": 'TX99p',
         "description": 'Mean annual change in extreme heat days',
         "path": 's3://cadcat/tmp/era/wrf/cae/mm4mean/ssp370/yr/TX99p/d02/TX99p.zarr',
@@ -10,7 +10,7 @@ export const metricsList = [
     },
     {
         "id": 1, 
-        "title": 'Precipitation',
+        "title": 'Extreme Precipitation',
         "variable": 'R99p',
         "description": 'Absolute change in 99th percentile 1-day accumulated precipitation',
         "path": 's3://cadcat/tmp/era/wrf/cae/mm4mean/ssp370/yr/R99p/d02/R99p.zarr',
@@ -19,7 +19,7 @@ export const metricsList = [
     },
     {
         "id": 2, 
-        "title": 'Wildfire',
+        "title": 'Fire Weather',
         "variable": 'ffwige50',
         "description": 'Change in median annual number of days with (FFWI) value greater than 50',
         "path": 's3://cadcat/tmp/era/wrf/cae/mm4mean/ssp370/yr/ffwige50/d02/ffwige50.zarr',

--- a/app/styles/dashboard/heatmap.scss
+++ b/app/styles/dashboard/heatmap.scss
@@ -27,8 +27,11 @@
 
 .color-scale-toggle {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: flex-end;
+  justify-content: flex-end;
   margin-right: 25px;
   margin-top: 14px;
+  margin-bottom: 20px;
+  gap: 15px;
 }


### PR DESCRIPTION
Added test code that will be removed later on, for color ramp options for both the Solar Drought Visualizer and the Data Explorer. 

To test, load either of the tools, and select different color ramps. The toggle switch can be used to revert the direction of the colors. 

The code might look a little wonky for now, and have some commented out sections. It will be cleaned up when decisions are made on the color ramps. 