### PR TITLE
Solar drought full map and new no-data points color

### DIFF
--- a/app/components/Data-Download-Tool/DataDownloadTool.tsx
+++ b/app/components/Data-Download-Tool/DataDownloadTool.tsx
@@ -29,7 +29,7 @@ import Typography from '@mui/material/Typography'
 import UndoOutlinedIcon from '@mui/icons-material/UndoOutlined'
 
 // Importing custom components and utilities
-import SidePanel from '@/app/components/Dashboard/RightSidepanel'
+import SidePanel from '@/app/components/Dashboard/RightSidePanel'
 import { useSidepanel } from '@/app/context/SidepanelContext'
 import PackageForm from '@/app/components/Data-Download-Tool/PackageForm'
 import { apiParamStrs, varUrl, modelVarUrls } from '@/app/lib/data-download/types'

--- a/app/components/Solar-Drought-Visualizer/MapboxMap.tsx
+++ b/app/components/Solar-Drought-Visualizer/MapboxMap.tsx
@@ -3,7 +3,7 @@
 import 'mapbox-gl/dist/mapbox-gl.css'
 import 'react-map-gl-geocoder/dist/mapbox-gl-geocoder.css'
 import React, { useRef, useState, useEffect, forwardRef, useImperativeHandle } from 'react'
-import { Marker, Map, MapMouseEvent, NavigationControl, ScaleControl, MapRef, ViewStateChangeEvent } from 'react-map-gl'
+import { Marker, Map, MapMouseEvent, NavigationControl, ScaleControl, MapRef } from 'react-map-gl'
 import GeocoderControl from './geocoder-control'
 import * as turf from '@turf/turf'
 
@@ -13,6 +13,14 @@ import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 import HtmlTooltip from '../Global/HtmlTooltip'
 import { usePhotoConfig } from '@/app/context/PhotoConfigContext'
 import '@/app/styles/dashboard/mapbox-map.scss'
+
+const INITIAL_VIEW_STATE = {
+    longitude: -120.4542,
+    latitude: 37.4,
+    zoom: 6
+}
+
+const GRID_FILL_COLOR = 'rgba(118, 150, 190, 0.8)'
 
 type Location = [number, number]
 
@@ -24,51 +32,47 @@ type MapboxMapProps = {
     width?: number;
     height: number;
 }
+
 const MapboxMap = forwardRef<MapRef | null, MapboxMapProps>(
     ({ locationSelected, setLocationSelected, mapMarker, setMapMarker, height }, ref) => {
-        const { photoConfigSelected } = usePhotoConfig();
+        const { photoConfigSelected } = usePhotoConfig()
 
         const mapRef = useRef<MapRef | null>(null)
         const [mapLoaded, setMapLoaded] = useState(false)
 
-        const initialViewState = {
-            longitude: -120.4542,
-            latitude: 37.0701,
-            zoom: 6
-        }
+        const initialViewState = INITIAL_VIEW_STATE
 
         // Forward the internal ref to the parent using useImperativeHandle
-        useImperativeHandle(ref, () => mapRef.current as MapRef);
+        useImperativeHandle(ref, () => mapRef.current as MapRef)
 
         const handleMapLoad = (e: any) => {
-            const map = e.target;
-            mapRef.current = map;
-            setMapLoaded(true);
-        };
+            const map = e.target
+            mapRef.current = map
+            setMapLoaded(true)
+        }
 
-        const handleMapClick = (e: MapMouseEvent) => {
-            const clickedPoint: [number, number] = [e.lngLat.lng, e.lngLat.lat];
-
+        const handleMapResize = () => {
             if (mapRef.current) {
-                const point = mapRef.current.project(clickedPoint);
-                const features = mapRef.current.queryRenderedFeatures(point, {
-                    layers: ['grid']
-                });
-
-                if (features && features.length > 0) {
-                    const selectedFeature = features[0];
-                    const centroid = turf.centroid(selectedFeature).geometry.coordinates;
-                    setMapMarker([centroid[0], centroid[1]]);
-                    setLocationSelected(centroid as [number, number]);
-                } else {
-                    console.log('No features found at the clicked location.');
-                }
+                const currentCenter = mapRef.current.getCenter()
+                mapRef.current.setCenter(currentCenter)
             }
         }
 
-        const handleMarkerDragEnd = (e: { lngLat: { lng: number; lat: number } }) => {
+        useEffect(() => {
             if (mapRef.current) {
-                const point = mapRef.current.project([e.lngLat.lng, e.lngLat.lat])
+                mapRef.current.on('resize', handleMapResize)
+            }
+
+            return () => {
+                if (mapRef.current) {
+                    mapRef.current.off('resize', handleMapResize)
+                }
+            }
+        }, [])
+
+        const handleLocationUpdate = (coordinates: [number, number]) => {
+            if (mapRef.current) {
+                const point = mapRef.current.project(coordinates)
                 const features = mapRef.current.queryRenderedFeatures(point, {
                     layers: ['grid']
                 })
@@ -76,32 +80,41 @@ const MapboxMap = forwardRef<MapRef | null, MapboxMapProps>(
                 if (features && features.length > 0) {
                     const selectedFeature = features[0]
                     const centroid = turf.centroid(selectedFeature).geometry.coordinates
-
                     setMapMarker([centroid[0], centroid[1]])
                     setLocationSelected(centroid as [number, number])
+                } else {
+                    console.log('No features found at the clicked location.')
                 }
             }
         }
 
+        const handleMapClick = (e: MapMouseEvent) => {
+            handleLocationUpdate([e.lngLat.lng, e.lngLat.lat])
+        }
+
+        const handleMarkerDragEnd = (e: { lngLat: { lng: number; lat: number } }) => {
+            handleLocationUpdate([e.lngLat.lng, e.lngLat.lat])
+        }
 
         // Update grid layer nodata cells based on photoConfigSelected
         useEffect(() => {
             if (mapRef.current && mapLoaded) {
+                const map = mapRef.current as unknown as mapboxgl.Map; // Type assertion to Mapbox GL JS Map
                 const maskAttribute = photoConfigSelected === 'Utility Configuration' ? 'srdumask' : 'srddmask'
 
-                if (mapRef.current) {
-                    mapRef.current.setPaintProperty('grid', 'fill-color', [
+                if (map) {
+                    map.setPaintProperty('grid', 'fill-color', [
                         'case',
                         ['==', ['get', maskAttribute], 0],
-                        'rgba(128, 128, 128, 0.3)',
+                        GRID_FILL_COLOR,
                         'rgba(0, 0, 0, 0)'
-                    ]);
+                    ])
                 }
             }
         }, [photoConfigSelected, mapLoaded])
 
         return (
-            <div className="map-container">
+            <div className="map-container" style={{ position: 'relative', width: '100%', height: '100%' }}>
                 <div id="map">
                     <Map
                         onLoad={handleMapLoad}
@@ -113,7 +126,7 @@ const MapboxMap = forwardRef<MapRef | null, MapboxMapProps>(
                         onClick={handleMapClick}
                         scrollZoom={false}
                         attributionControl={false}
-                        minZoom={3.5}
+                        minZoom={5}
                     >
                         {mapMarker && (
                             <Marker
@@ -128,12 +141,10 @@ const MapboxMap = forwardRef<MapRef | null, MapboxMapProps>(
                         <GeocoderControl zoom={13} mapboxAccessToken={process.env.NEXT_PUBLIC_MAPBOX_TOKEN || ''} position="top-left" />
                     </Map>
                 </div>
-                {/* Legend */}
+                {/* Legend Overlay */}
                 <div className="map-container__legend">
                     <div className="map-container__legend-color-box"></div>
-
-                    <p>Location with land restrictions</p>  
-
+                    <p>Location with land restrictions</p>
                     <HtmlTooltip
                         textFragment={
                             <React.Fragment>

--- a/app/components/Solar-Drought-Visualizer/SolarDroughtVisualizer.tsx
+++ b/app/components/Solar-Drought-Visualizer/SolarDroughtVisualizer.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect, useRef } from 'react'
+import React, { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 
 import Tooltip from '@mui/material/Tooltip'
 import IconButton from '@mui/material/IconButton'
@@ -31,12 +31,11 @@ import Button from '@mui/material/Button'
 import Grid from '@mui/material/Unstable_Grid2'
 import Box from '@mui/material/Box'
 import Typography from '@mui/material/Typography'
-import SidePanel from '@/app/components/Dashboard/RightSidepanel'
+import SidePanel from '@/app/components/Dashboard/RightSidePanel'
 import { useSidepanel } from '@/app/context/SidepanelContext'
 import { usePhotoConfig } from '@/app/context/PhotoConfigContext'
 
 import { useDidMountEffect } from "@/app/utils/hooks"
-
 
 import MapboxMap from '@/app/components/Solar-Drought-Visualizer/MapboxMap'
 import Heatmap from '@/app/components/Heatmap/Heatmap'
@@ -45,18 +44,21 @@ import { ApiResponse } from './DataType'
 import '@/app/styles/dashboard/solar-drought-visualizer.scss'
 import LoadingSpinner from '../Global/LoadingSpinner'
 
-const MAP_HEIGHT = 615
+const MAP_HEIGHT = 550
 const HEATMAP_HEIGHT = 500
+const ITEM_HEIGHT = 48
+const ITEM_PADDING_TOP = 8
 
 type Location = [number, number]
-
 type apiParams = {
     point: Location | null,
     configQueryStr: string,
 }
+type LocationStatus = 'none' | 'data' | 'no-data'
 
-const ITEM_HEIGHT = 48;
-const ITEM_PADDING_TOP = 8;
+interface QueriedData {
+    data: number[][]
+}
 
 const MenuProps: any = {
     PaperProps: {
@@ -77,11 +79,42 @@ const MenuProps: any = {
 }
 
 export default function SolarDroughtViz() {
+    // Context
     const { open, toggleOpen } = useSidepanel()
-    const { photoConfigSelected, setPhotoConfigSelected, photoConfigList } = usePhotoConfig()
+    const { photoConfigSelected, photoConfigList } = usePhotoConfig()
+    const [apiParams, setApiParams] = useState<apiParams>({ point: null, configQueryStr: 'srdu' })
 
-    const heatmapContainerRef = useRef<HTMLBoxElement>(null)
+    // Derived state
+    const derivedConfigStr = useMemo(() => {
+        return photoConfigSelected === 'Utility Configuration' ? 'srdu' : 'srdd'
+    }, [photoConfigSelected])
+
+    // Parameters state
+    const [isColorRev, setIsColorRev] = useState<boolean>(false)
+    const [globalWarmingSelected, setGlobalWarmingSelected] = useState('2')
+    const globalWarmingList = ['2']
+
+    // Map & location state
+    const mapRef = useRef<any>(null)
+    const [locationStatus, setLocationStatus] = useState<LocationStatus>('none')
+    const [mapMarker, setMapMarker] = useState<[number, number] | null>(null)
+
+    // Heatmap state
+    const heatmapContainerRef = useCallback((node: HTMLDivElement | null) => {
+        if (node !== null) {
+            setHeatmapContainer(node)
+        }
+    }, [])
+    const [heatmapContainer, setHeatmapContainer] = useState<HTMLDivElement | null>(null)
     const [heatmapWidth, setHeatmapWidth] = useState(0)
+    const [queriedData, setQueriedData] = useState<QueriedData | null>(null)
+    const [isPointValid, setIsPointValid] = useState<boolean>(false)
+    const [isLoading, setIsLoading] = useState<boolean>(false)
+    const [useAltColor, setUseAltColor] = useState(false)
+    const [reverseColorMap, setReverseColorMap] = useState(false)
+
+    // UI state
+    const [accordionExpanded, setAccordionExpanded] = useState(true)
 
     // TEMP: for color ramp options
     const [currentColorMap, setCurrentColorMap] = useState<string>('Oranges')
@@ -91,98 +124,171 @@ export default function SolarDroughtViz() {
         'BuPu', 'GnBu', 'OrRd', 'PuBuGn', 'PuBu', 'PuRd', 'RdPu', 'YlGnBu', 'YlGn', 'YlOrBr', 'YlOrRd'
     ]
 
-    const [isColorRev, setIsColorRev] = useState<boolean>(false)
-
-    const [globalWarmingSelected, setGlobalWarmingSelected] = useState('2')
-    const globalWarmingList = ['2']
-    const [configStr, setConfigStr] = useState<string>('')
-    const [queriedData, setQueriedData] = useState(null)
-    const [isLocationSet, setIsLocationSet] = useState<boolean>(false)
-    const [accordionExpanded, setAccordionExpanded] = useState(true)
-    const mapRef = useRef<any>(null) // Ref for the Mapbox component
-    const [mapMarker, setMapMarker] = useState<[number, number] | null>(null)
-    const [isLoading, setIsLoading] = useState<boolean>(false)
-    const [isPointValid, setIsPointValid] = useState<boolean>(false)
-    const [useAltColor, setUseAltColor] = useState(false)
-
-    // ACCORDION
-    const expandMap = () => {
-        setAccordionExpanded((prevExpanded: boolean) => !prevExpanded)
+    // Handlers
+    const handleAccordionChange = () => {
+        if (apiParams.point !== null) {
+            setAccordionExpanded(!accordionExpanded)
+        }
     }
 
     // API PARAMS
-    const [apiParams, setApiParams] = useState<apiParams>({
-        point: null,
-        configQueryStr: 'srdu',
-    })
-
-    useEffect(() => {
-        if (photoConfigSelected == "Utility Configuration") {
-            setConfigStr('srdu')
-        } else if (photoConfigSelected == "Distributed Configuration") {
-            setConfigStr('srdd')
-        }
-    }, [photoConfigSelected])
-
-    useEffect(() => {
-        updateApiParams({
-            configQueryStr: configStr
-        })
-
-    }, [configStr])
-
-    // Ref to store previous state
     const prevApiParams = useRef<apiParams>(apiParams)
 
+    const onFormDataSubmit = useCallback(async () => {
+        if (!apiParams.point || locationStatus !== 'data') {
+            return
+        }
+
+        setIsLoading(true)
+
+        const [long, lat] = apiParams.point
+        const s3Url = `s3://cadcat/tmp/era/wrf/cae/mm4mean/ssp370/mon/${apiParams.configQueryStr}/d03`
+        const apiUrl = `https://2fxwkf3nc6.execute-api.us-west-2.amazonaws.com/point/${long},${lat}`
+        const queryParams = new URLSearchParams({
+            url: s3Url,
+            variable: apiParams.configQueryStr
+        })
+        const fullUrl = `${apiUrl}?${queryParams.toString()}`
+
+        try {
+            const res = await fetch(fullUrl)
+            if (!res.ok) {
+                console.error('Failed with status:', res.status)
+                setQueriedData(null)
+                setIsPointValid(false)
+                return
+            }
+            const newData = await res.json()
+            if (newData) {
+                setQueriedData(newData)
+                setIsPointValid(true)
+            } else {
+                setQueriedData(null)
+                setIsPointValid(false)
+            }
+        } catch (err) {
+            console.error('Fetch error:', err)
+            setQueriedData(null)
+            setIsPointValid(false)
+        } finally {
+            setIsLoading(false)
+        }
+    }, [apiParams.point, apiParams.configQueryStr, locationStatus])
+
     useEffect(() => {
-        // Compare previous and current state
         if (JSON.stringify(prevApiParams.current) !== JSON.stringify(apiParams)) {
             onFormDataSubmit()
         }
-
-        // Update the ref to the current apiParams
         prevApiParams.current = apiParams
-    }, [apiParams])
+    }, [apiParams, onFormDataSubmit])
 
-    function setLocationSelected(point: Location | null) {
-        updateApiParams({
-            point: point
-        })
-        setIsLocationSet(true)
-    }
-
-    // QUERIED DATA
     useEffect(() => {
         if (queriedData) {
             setIsLoading(false)
+            setIsPointValid(true)
+        }
+    }, [queriedData])
 
-            if (queriedData.data[0][0]) {
-                // Point is valid
-                setIsPointValid(true)
+    useEffect(() => {
+        if (mapRef.current) {
+            mapRef.current.resize()
+        }
+    }, [accordionExpanded])
+
+    useEffect(() => {
+        if (!heatmapContainer) return
+
+        const resizeObserver = new ResizeObserver(entries => {
+            for (const entry of entries) {
+                const newWidth = entry.contentRect.width
+                setHeatmapWidth(newWidth)
+            }
+        })
+
+        resizeObserver.observe(heatmapContainer)
+
+        return () => {
+            resizeObserver.disconnect()
+        }
+    }, [heatmapContainer])
+
+    const checkLocationStatus = useCallback((point: Location | null, config: string) => {
+        if (!point) {
+            setLocationStatus('none')
+            return
+        }
+
+        if (mapRef.current) {
+            const mapboxPoint = mapRef.current.project(point)
+            const features = mapRef.current.queryRenderedFeatures(mapboxPoint, {
+                layers: ['grid']
+            })
+
+            if (features && features.length > 0) {
+                const selectedFeature = features[0]
+                const maskAttribute = config === 'Utility Configuration' ? 'srdumask' : 'srddmask'
+                const gridValue = selectedFeature.properties?.[maskAttribute]
+                
+                const newStatus = gridValue === 1 ? 'data' : 'no-data'
+                setLocationStatus(newStatus)
+
+                if (newStatus === 'data') {
+                    onFormDataSubmit()
+                } else {
+                    setQueriedData(null)
+                    setIsPointValid(false)
+                }
             } else {
-                // Point is Invalid
+                setLocationStatus('no-data')
+                setQueriedData(null)
                 setIsPointValid(false)
             }
         }
+    }, [mapRef, onFormDataSubmit])
 
-    }, [queriedData])
-
-    // IS LOADING
+    // Check location status when photoConfigSelected or point changes
     useEffect(() => {
-        if (!isLoading && !isPointValid) {
-            console.log('map point invalid')
+        if (apiParams.point) {
+            checkLocationStatus(apiParams.point, photoConfigSelected)
+        }
+    }, [photoConfigSelected, apiParams.point, checkLocationStatus])
+
+    // Update apiParams when configStr changes (including when photoConfigSelected changes)
+    useEffect(() => {
+        setApiParams(prevParams => ({
+            ...prevParams,
+            configQueryStr: derivedConfigStr
+        }))
+    }, [derivedConfigStr])
+
+    function setLocationSelected(point: Location | null) {
+        if (!point) {
+            setLocationStatus('none')
+            updateApiParams({ point: null })
+            return
         }
 
-    }, [isLoading])
+        // Get the grid value at this point
+        if (mapRef.current) {
+            const mapboxPoint = mapRef.current.project(point)
+            const features = mapRef.current.queryRenderedFeatures(mapboxPoint, {
+                layers: ['grid']
+            })
 
-    // Ensure the Mapbox map resizes when the accordion is expanded
-    useEffect(() => {
-        if (accordionExpanded && mapRef.current) {
-            setTimeout(() => {
-                mapRef.current?.resize() // Force map resize after expansion
-            }, 300) // Delay to allow the accordion transition to complete
+            if (features && features.length > 0) {
+                const selectedFeature = features[0]
+                const maskAttribute = photoConfigSelected === 'Utility Configuration' ? 'srdumask' : 'srddmask'
+                const gridValue = selectedFeature.properties?.[maskAttribute]
+                
+                // Set status based on grid value
+                setLocationStatus(gridValue === 1 ? 'data' : 'no-data')
+                updateApiParams({ point })
+                
+                // Collapse accordion on selection
+                setAccordionExpanded(false)
+            }
         }
-    }, [accordionExpanded])
+    }
 
     function updateApiParams(newParams: Partial<apiParams>) {
         setApiParams(prevParams => ({
@@ -191,56 +297,16 @@ export default function SolarDroughtViz() {
         }))
     }
 
-    const onFormDataSubmit = async () => {
-        if (!apiParams.point) {
-            return
-        }
-
-        setIsLoading(true)
-
-        const [long, lat] = apiParams.point
-        const apiUrl = `https://2fxwkf3nc6.execute-api.us-west-2.amazonaws.com/point/${long},${lat}`
-
-        const queryParams = new URLSearchParams({
-            url: `s3://cadcat/tmp/era/wrf/cae/mm4mean/ssp370/mon/${configStr}/d03`,
-            variable: apiParams.configQueryStr
-        })
-        const fullUrl = `${apiUrl}?${queryParams.toString()}`
-
-        try {
-            const res = await fetch(fullUrl)
-            const newData = await res.json()
-
-            if (newData) {
-                setQueriedData(newData)
-
-
-            }
-        } catch (err) {
-            console.log(err)
-        }
-
+    const handleColorChange = () => {
+        setUseAltColor((prev) => !prev)
     }
 
-    // RESPONSIVE HEATMAP WIDTH (D3 requires a width specification)
-    useEffect(() => {
-        if (!heatmapContainerRef.current) return
-        const resizeObserver = new ResizeObserver(entries => {
-            for (const entry of entries) {
-                setHeatmapWidth(entry.contentRect.width)
-            }
-        })
-
-        resizeObserver.observe(heatmapContainerRef.current)
-
-        return () => {
-            resizeObserver.disconnect()
+    const handleSummaryClick = (event: React.MouseEvent) => {
+        if (apiParams.point === null) {
+            event.preventDefault()
+            event.stopPropagation()
         }
-    }, [])
-
-    const handleColorChange = () => {
-        setUseAltColor((prev) => !prev);
-    };
+    }
 
     return (
         <Box className="solar-drought-tool tool-container tool-container--padded" aria-label="Solar Drought Visualizer" role="region">
@@ -257,27 +323,26 @@ export default function SolarDroughtViz() {
             {/* Main viz content */}
             <Grid container xs={12}>
                 {/* Heatmap parameters section */}
-                <Grid xs={isLocationSet ? 12 : 0} sx={{ display: isLocationSet ? 'block' : 'none', transition: 'all 0.3s ease' }}>
-                    {queriedData && !isLoading && isPointValid &&
-                        (<Box>
-                            <Box className="flex-params">
-                                <Box className="flex-params__item">
-                                    <Typography className="option-group__title" variant="body2" aria-label="Global Warming Level">Global Warming Level</Typography>
-                                    <Typography variant="body1" aria-label={`Selected Global Warming Level: ${globalWarmingSelected}`}>{globalWarmingSelected}°</Typography>
-                                </Box>
-                                <Box className="flex-params__item">
-                                    <Typography className="option-group__title" variant="body2" aria-label="Photovoltaic Configuration">Photovoltaic Configuration</Typography>
-                                    <Typography variant="body1" aria-label={`Selected Photovoltaic Configuration: ${photoConfigSelected}`}>{photoConfigSelected}</Typography>
-                                </Box>
-                                <Box className="flex-params__item">
-                                    <Typography className='inline' variant="subtitle1" aria-label="Edit parameters">Edit parameters</Typography>
-                                    <IconButton className='inline' onClick={toggleOpen} aria-label="Open settings">
-                                        <SettingsOutlinedIcon />
-                                    </IconButton>
-                                </Box>
+                <Grid xs={12}>
+                    <Box>
+                        <Box className="flex-params">
+                            <Box className="flex-params__item">
+                                <Typography className="option-group__title" variant="body2" aria-label="Global Warming Level">Global Warming Level</Typography>
+                                <Typography variant="body1" aria-label={`Selected Global Warming Level: ${globalWarmingSelected}`}>{globalWarmingSelected}°</Typography>
                             </Box>
-
-                            {/* Global warming level information */}
+                            <Box className="flex-params__item">
+                                <Typography className="option-group__title" variant="body2" aria-label="Photovoltaic Configuration">Photovoltaic Configuration</Typography>
+                                <Typography variant="body1" aria-label={`Selected Photovoltaic Configuration: ${photoConfigSelected}`}>{photoConfigSelected}</Typography>
+                            </Box>
+                            <Box className="flex-params__item">
+                                <Typography className='inline' variant="subtitle1" aria-label="Edit parameters">Edit parameters</Typography>
+                                <IconButton className='inline' onClick={toggleOpen} aria-label="Open settings">
+                                    <SettingsOutlinedIcon />
+                                </IconButton>
+                            </Box>
+                        </Box>
+                        {/* Global warming level information */}
+                        {queriedData && !isLoading && isPointValid &&
                             <Box className="alerts" sx={{ maxWidth: '100%' }}>
                                 <Alert variant="filled" severity="info" color="info" aria-label="Global models estimate information">Global models estimate that 2° global warming levels (GWL) will be reached between <strong>2037</strong> and <strong>2061</strong>
                                     <Box className="cta">
@@ -285,13 +350,13 @@ export default function SolarDroughtViz() {
                                     </Box>
                                 </Alert>
                             </Box>
-                        </Box>
-                        )}
+                        }
+                    </Box>
                 </Grid>
             </Grid>
             <Accordion
                 expanded={accordionExpanded}
-                onChange={() => setAccordionExpanded(!accordionExpanded)}
+                onChange={handleAccordionChange}
                 slots={{ transition: Fade as AccordionSlots['transition'] }}
                 slotProps={{ transition: { timeout: 400 } }}
                 sx={[
@@ -318,10 +383,9 @@ export default function SolarDroughtViz() {
                 ]}
             >
 
-                <Grid container xs={12}>
-
+                <Grid container xs={12} justifyContent="flex-end">
                     {/* Colormap toggle for heatmap */}
-                    <Grid xs={isLocationSet ? 8.5 : 0} sx={{ display: isLocationSet ? 'block' : 'none', transition: 'all 0.3s ease' }}>
+                    <Grid xs={locationStatus !== 'none' ? (accordionExpanded ? 12 : 8.5) : 0} sx={{ display: locationStatus !== 'none' ? 'block' : 'none', transition: 'all 0.3s ease' }}>
                         {isPointValid && (
                             <div className="color-scale-toggle">
                                 <div className="option-group option-group--vertical">
@@ -351,8 +415,7 @@ export default function SolarDroughtViz() {
                                         <FormControlLabel
                                             control={<Switch onChange={handleColorChange} color="secondary" />}
                                             label="Alternative color palette"
-                                        />
-                                    </FormGroup> */}
+                                        /> */}
                                     <FormGroup>
                                         <FormControlLabel
                                             control={<Switch onChange={() => setIsColorRev(!isColorRev)} color="secondary" />}
@@ -361,40 +424,43 @@ export default function SolarDroughtViz() {
                                     </FormGroup>
                                 </div>
                             </div>
-
                         )}
                     </Grid>
 
                     {/* Locator map instruction section */}
-                    <Grid xs={3.5} sx={{ display: 'flex', flexDirection: 'column', justifyContent: 'flex-end' }}>
-                        <AccordionSummary
-                            expandIcon={<ExpandMoreIcon sx={{ transform: 'rotate(90deg)' }} aria-label="Expand or collapse the section" />}
-                            aria-controls="panel1-content"
-                            id="panel1-header"
-                            sx={{
-                                '& .MuiAccordionSummary-content': {
-                                    marginTop: '20px', // Override the default margin to keep the Accordion Summary from vertically shifting when expanding
-                                    marginBottom: '20px',
-                                },
-                            }}
-                        >
-                            <EditLocationOutlinedIcon aria-label="Edit location" />
-                            <Typography
-                                className="inline"
-                                variant="h5"
-                                style={{
-                                    'marginLeft': '10px',
-                                    'textDecoration': !accordionExpanded ? 'underline' : 'none',
+                    <Grid xs={12} sx={{ display: 'flex', justifyContent: accordionExpanded ? 'flex-start' : 'flex-end' }}>
+                        <Box sx={{ width: accordionExpanded ? '100%' : 'auto' }}>
+                            <AccordionSummary
+                                onClick={handleSummaryClick}
+                                expandIcon={apiParams.point !== null ? <ExpandMoreIcon className="rotated-icon" /> : null}
+                                aria-controls="panel1-content"
+                                id="panel1-header"
+                                sx={{
+                                    '& .MuiAccordionSummary-content': {
+                                        marginTop: '20px',
+                                        marginBottom: '20px',
+                                        justifyContent: accordionExpanded ? 'flex-start' : 'flex-end',
+                                    },
+                                    width: '100%',
                                 }}
-                                aria-label={isLocationSet ? "Change your location" : "Select your location"}
                             >
-                                {isLocationSet ? "Change your location" : "Select your location"}
-                            </Typography>
-                        </AccordionSummary>
+                                <EditLocationOutlinedIcon aria-label="Edit location" />
+                                <Typography
+                                    className="inline"
+                                    variant="h5"
+                                    style={{
+                                        'marginLeft': '10px',
+                                    }}
+                                    aria-label={locationStatus !== 'none' ? "Change your location" : "Select your location"}
+                                >
+                                    {locationStatus !== 'none' ? "Change your location" : "Select your location"}
+                                </Typography>
+                            </AccordionSummary>
+                        </Box>
                     </Grid>
 
                     {/* Heatmap section */}
-                    <Grid xs={accordionExpanded ? 8.5 : 12}
+                    <Grid xs={accordionExpanded ? 0 : 8.5}
                         sx={{
                             maxWidth: '100%',
                             pr: 4,
@@ -402,57 +468,54 @@ export default function SolarDroughtViz() {
                             paddingRight: 0,
                         }}
                     >
-                        {!isLoading && !isPointValid && isLocationSet &&
-                            (
-                                <Box>
-                                    <Alert variant="grey" severity="info" aria-label="Location with restrictions alert">You have selected a location with land use or land cover restrictions. No data will be returned.&nbsp;
-                                        <span
-                                            className={accordionExpanded ? '' : 'underline'}
-                                            onClick={accordionExpanded ? undefined : expandMap}
-                                            aria-label="Select another location"
-                                        >
-                                            <strong>Select another location </strong>
-                                        </span>
-                                        to try again
-                                    </Alert>
-                                </Box>
-                            )
-                        }
-                        <Box
-                            ref={heatmapContainerRef}
-                            className={'solar-drought-tool__heatmap' + (isLoading ? ' loading-screen' : '') + (!isLoading && !isPointValid ? ' invalid-point-screen' : '')}
-                        >
-                            {!isLoading && isPointValid &&
-                                (
+                        {locationStatus === 'no-data' && (
+                            <Box sx={{ marginBottom: '30px' }}                                 
+                                style={{ display: accordionExpanded ? 'none' : 'block' }}
+                            >
+                                <Alert variant="grey" severity="info">
+                                    You have selected a location with land use or land cover restrictions. No data will be returned.&nbsp;
+                                    <span
+                                        onClick={accordionExpanded ? undefined : handleAccordionChange}
+                                        aria-label="Select another location"
+                                    >
+                                        <strong>Select another location </strong>
+                                    </span>
+                                    to try again
+                                </Alert>
+                            </Box>
+                        )}
+                        {locationStatus === 'data' && (
+                            <Box
+                                ref={heatmapContainerRef}
+                                className={'solar-drought-tool__heatmap' + (isLoading ? ' loading-screen' : '')}
+                                style={{ display: accordionExpanded ? 'none' : 'block' }}
+                            >
+                                {isLoading && (
+                                    <Box style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
+                                        <LoadingSpinner aria-label="Loading heatmap data" />
+                                    </Box>
+                                )}
+                                {!isLoading && isPointValid && (
                                     <Heatmap
                                         width={heatmapWidth}
                                         height={HEATMAP_HEIGHT}
-                                        data={queriedData && queriedData}
+                                        data={queriedData}
                                         useAltColor={useAltColor}
                                         aria-label="Heatmap visualization"
                                         currentColorMap={currentColorMap}
                                         isColorRev={isColorRev}
                                     />
-                                )
-                            }
-                            {isLoading &&
-                                (
-                                    <Box style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', height: '100%' }}>
-                                        <LoadingSpinner aria-label="Loading heatmap data" />
-                                    </Box>
-                                )
-                            }
-                        </Box>
+                                )}
+                            </Box>
+                        )}
                     </Grid>
 
                     {/* Locator map section */}
-                    <Grid xs={3.5} >
+                    <Grid xs={accordionExpanded ? 12 : 3.5} sx={{ alignItems: 'flex-end' }}>
                         <AccordionDetails
-                            sx={{
-                                paddingTop: '0px',
-                            }}
+                            className="custom-accordion-details"
                         >
-                            <Box className="solar-drought-tool__map" style={{ width: '100%' }}>
+                            <Box className="solar-drought-tool__map">
                                 <MapboxMap
                                     mapMarker={mapMarker}
                                     setMapMarker={setMapMarker}

--- a/app/components/Solar-Drought-Visualizer/geocoder-control.tsx
+++ b/app/components/Solar-Drought-Visualizer/geocoder-control.tsx
@@ -36,7 +36,8 @@ export default function GeocoderControl(props: GeocoderControlProps) {
       const ctrl = new MapboxGeocoder({
         ...props,
         marker: false,
-        accessToken: props.mapboxAccessToken
+        accessToken: props.mapboxAccessToken,
+        bbox: [-124.482, 32.528, -114.131, 42.009] // California bounding box
       });
       ctrl.on('loading', noop);
       ctrl.on('results', noop);

--- a/app/styles/dashboard/mapbox-map.scss
+++ b/app/styles/dashboard/mapbox-map.scss
@@ -10,22 +10,37 @@
     }
 
     &__legend {
+      position: absolute;
+      top: 60px;
+      left: 10px;
       display: flex;
       align-items: center;
+      height: 36px;
+      background-color: white;
+      padding: 6px 10px 4px 10px;
+      border-radius: 4px;
+      box-shadow: none;
+      font-size: 0.875rem;
 
       &-color-box {
         width: 16px;
         height: 16px;
-        background-color: rgba(128, 128, 128, 0.3);
+        background-color: rgba(118, 150, 190, 0.8);
         margin-right: 10px;
       }
     }
   }
 }
 
+.inline-tooltip {
+  margin-left: 6px;
+  margin-top: 4px;
+}
+
 .mapboxgl-ctrl-geocoder.mapboxgl-ctrl {
-    // so geocoder component has same styling as navigation component
-    box-shadow: rgba(0, 0, 0, 0.1) 0px 0px 0px 2px;
+    // so geocoder component has same styling as no-data legend
+    width: 275px !important;
+    box-shadow: none !important;
 }
 
 .mapboxgl-popup.map-popup {
@@ -33,7 +48,7 @@
         background-color: white;
         border: 0;
         border-radius: 4px;
-        padding: 8px 16px;
+        padding: 10px 16px;
         box-shadow: none;
     }
 

--- a/app/styles/dashboard/solar-drought-visualizer.scss
+++ b/app/styles/dashboard/solar-drought-visualizer.scss
@@ -1,6 +1,6 @@
 .solar-drought-tool {
   &__intro {
-    margin: 30px 16px;
+    margin: 0 16px 16px 16px;
     display: flex;
     flex-direction: column;
     gap: 15px;
@@ -8,6 +8,10 @@
 
   &__heatmap {
     transition: width 1s ease;
+  }
+
+  &__map {
+    width: 100%;
   }
 
   .loading-screen,
@@ -23,12 +27,43 @@
   }
 
   .invalid-point-screen {
-    margin-top: 30px;
+    margin-top: 0;
   }
 
   .alerts {
     margin-left: 103px;
     margin-right: 14px;
+  }
+
+  .map-tooltip {
+    position: absolute;
+    background-color: white;
+    border-radius: 16px;
+    color: black;
+    padding: 5px;
+    margin-left: 15px;
+    transform: translateY(-50%);
+    z-index: 1000;
+
+    &:after {
+      content: "";
+      position: absolute;
+      border-width: 5px;
+      left: -10px;
+      top: 50%;
+      transform: translateY(-50%);
+      border-color: transparent black transparent transparent;
+    }
+  }
+
+  .custom-accordion-details {
+    display: block !important; /* Override MUI's default behavior */
+    padding-top: 0px;
+    z-index: 1;
+  }
+
+  .rotated-icon {
+    transform: rotate(90deg);
   }
 }
 


### PR DESCRIPTION
**Desired outcome / steps to test** 

Locator map:
- loads full width
- reduces after user location selection
- is expandable in a horizontal accordion style with icon click

No-data points:
- refined color
- legend is more visible inside the map on upper left under geolocator text field
- don't send a request when selected
- don't obscure (lay over top of) the map labels

Geolocation:
- is restricted to California

Parameters list 
- is always present

P.S. I squashed the commits so it was easier for you to review.

P.S.S. A lot of the changes are code organization: organizing similar types of code together in SolarDroughtVisualizer. And I'm realizing that I work without semi-colons and maybe you work with semi-colons? When I run prettier in my IDE, it formats them out.
